### PR TITLE
Fix #231: Remove page-level scrolling in ShortcutGenerator

### DIFF
--- a/app/src/components/Layout.tsx
+++ b/app/src/components/Layout.tsx
@@ -189,9 +189,7 @@ const Layout = () => {
           width: { sm: `calc(100% - ${desktopOpen ? drawerWidth : 0}px)` },
           marginTop: '64px',
           height: 'calc(100vh - 64px)',
-          overflow: 'hidden',
-          display: 'flex',
-          flexDirection: 'column',
+          overflow: 'auto',
           boxSizing: 'border-box'
         }}
       >

--- a/app/src/pages/ShortcutGenerator.tsx
+++ b/app/src/pages/ShortcutGenerator.tsx
@@ -555,7 +555,7 @@ const ShortcutGenerator = () => {
       window.removeEventListener('resize', updateListHeight);
       resizeObserver.disconnect();
     };
-  }, [functionConfigExpanded, specialInputsExpanded]);
+  }, [functionConfigExpanded, specialInputsExpanded, connections.length]);
 
   return (
     <Box sx={{ 


### PR DESCRIPTION
This PR fixes issue #231 by removing page-level scrolling in the ShortcutGenerator component.

## Changes
- Made the main container use flexbox with \height: 100%\ and \overflow: hidden\ to prevent page-level scrolling
- Made the List container fill available space dynamically using flexbox
- Added dynamic height calculation for react-window List using a ref and ResizeObserver
- Updated Layout component to have fixed height (\calc(100vh - 64px)\) and prevent overflow

## Result
- Only the react-window List now scrolls internally
- Page-level scrolling is disabled
- The List height adjusts dynamically based on available space

Closes #231

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes page-level scrolling by making the ShortcutGenerator a full-height flex layout and sizes the virtualized list dynamically via ResizeObserver.
> 
> - **UI/Layout**:
>   - `app/src/components/Layout.tsx`: Set main content to fixed viewport height (`height: calc(100vh - 64px)`), enable internal scrolling (`overflow: auto`), and enforce `boxSizing: border-box`.
>   - `app/src/pages/ShortcutGenerator.tsx`:
>     - Convert root container to full-height flex column with `overflow: hidden`; prevent page-level scroll.
>     - Make header/config sections non-growing (`flexShrink: 0`).
>     - Make list panel fill remaining space (`flex: 1`, `overflow: hidden`, `minHeight: 0`).
>     - Add dynamic list sizing: `useRef` + `useEffect` with `ResizeObserver` and window resize to compute `listHeight`; pass to `react-window` `List` instead of fixed `600`.
>     - Wire list container via `ref` to measure height; adjust when sections collapse/expand and when connections change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d018f0d72df1dde0d7fb702125f3e6b2f95fe27b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->