### PR TITLE
Migrate repository to Incomplete-Outputs-Lab organization

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Shugo Kawamura
+Copyright (c) 2020 未完成成果物研究所
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # vmix-utility
 
-[![Test Build](https://github.com/FlowingSPDG/vmix-utility/actions/workflows/test-build.yml/badge.svg)](https://github.com/FlowingSPDG/vmix-utility/actions/workflows/test-build.yml)
-[![Publish Release](https://github.com/FlowingSPDG/vmix-utility/actions/workflows/release.yml/badge.svg)](https://github.com/FlowingSPDG/vmix-utility/actions/workflows/release.yml)
+[![Test Build](https://github.com/Incomplete-Outputs-Lab/vmix-utility/actions/workflows/test-build.yml/badge.svg)](https://github.com/Incomplete-Outputs-Lab/vmix-utility/actions/workflows/test-build.yml)
+[![Publish Release](https://github.com/Incomplete-Outputs-Lab/vmix-utility/actions/workflows/release.yml/badge.svg)](https://github.com/Incomplete-Outputs-Lab/vmix-utility/actions/workflows/release.yml)
 
 ### About / 概要
 
@@ -11,9 +11,9 @@ vMix接続と操作を管理するデスクトップアプリケーション。T
 
 ### Installation / インストール
 
-Download the latest version for your platform from [Releases](https://github.com/FlowingSPDG/vmix-utility/releases):
+Download the latest version for your platform from [Releases](https://github.com/Incomplete-Outputs-Lab/vmix-utility/releases):
 
-[Releases](https://github.com/FlowingSPDG/vmix-utility/releases)から最新版をダウンロードしてください：
+[Releases](https://github.com/Incomplete-Outputs-Lab/vmix-utility/releases)から最新版をダウンロードしてください：
 
 - **Windows**: `.msi` installer
 - **macOS**: `.dmg` file (Intel and Apple Silicon)
@@ -37,10 +37,10 @@ MITライセンス - 詳細は[LICENSE](LICENSE)ファイルを参照してく�
 
 ### Links / リンク
 
-- [Download Latest Release](https://github.com/FlowingSPDG/vmix-utility/releases/latest)
-- [Report Issues](https://github.com/FlowingSPDG/vmix-utility/issues)
+- [Download Latest Release](https://github.com/Incomplete-Outputs-Lab/vmix-utility/releases/latest)
+- [Report Issues](https://github.com/Incomplete-Outputs-Lab/vmix-utility/issues)
 - [vMix Official Website](https://www.vmix.com/)
 
 ### Developer / 開発者
 
-**Shugo Kawamura** - [@FlowingSPDG](https://github.com/FlowingSPDG)
+**未完成成果物研究所**

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 name = "app"
 version = "2.2.0"
 description = "app"
-authors = ["Shugo Kawamura"]
+authors = ["未完成成果物研究所"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -44,7 +44,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEJFQTFCMDRDQURFNkYxMgpSV1FTYjk3S0JCdnFDNStGZnJNOVRLdjNHaGRObld3Ukcyekpyem13emhRcHoxOVV4Z0Fna0tQcAo=",
       "endpoints": [
-        "https://github.com/FlowingSPDG/vmix-utility/releases/latest/download/latest.json"
+        "https://github.com/Incomplete-Outputs-Lab/vmix-utility/releases/latest/download/latest.json"
       ]
     }
   }

--- a/app/src/pages/Developer.tsx
+++ b/app/src/pages/Developer.tsx
@@ -35,7 +35,7 @@ const TwitchIcon = (props: SvgIconProps) => (
 
 const Developer = () => {
   const { resolvedTheme } = useTheme();
-  const repositoryUrl = 'https://github.com/FlowingSPDG/vmix-utility';
+  const repositoryUrl = 'https://github.com/Incomplete-Outputs-Lab/vmix-utility';
   const developerGitHub = 'https://github.com/FlowingSPDG';
   const sponsorUrl = 'https://github.com/sponsors/FlowingSPDG';
   const twitchSupportUrl = 'https://subs.twitch.tv/flowingspdg';
@@ -101,7 +101,7 @@ const Developer = () => {
                 </Avatar>
                 <Box>
                   <Typography variant="h6" component="h2">
-                    Shugo "FlowingSPDG" Kawamura
+                    未完成成果物研究所
                   </Typography>
                   <Typography variant="body2" color="text.secondary">
                     Developer & Maintainer
@@ -110,7 +110,7 @@ const Developer = () => {
               </Box>
               
               <Typography variant="body2" gutterBottom>
-                Creator and main developer of vmix-utility. Passionate about broadcasting technology and creating tools to enhance live streaming workflows.
+                Development team creating tools to enhance live streaming workflows and broadcasting technology.
               </Typography>
               
               <Button
@@ -214,7 +214,7 @@ const Developer = () => {
               <Typography variant="body2" component="pre" sx={{ fontFamily: 'monospace', whiteSpace: 'pre-wrap' }}>
                 {`MIT License
 
-Copyright (c) 2020 Shugo Kawamura
+Copyright (c) 2020 未完成成果物研究所
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -258,6 +258,25 @@ SOFTWARE.`}
             </Typography>
             
             <List>
+              <ListItem sx={{ pl: 0 }}>
+                <ListItemIcon>
+                  <Avatar sx={{ bgcolor: 'primary.main' }}>
+                    <Code />
+                  </Avatar>
+                </ListItemIcon>
+                <ListItemText
+                  primary={
+                    <Link
+                      component="button"
+                      onClick={() => openInBrowser('https://github.com/FlowingSPDG')}
+                      sx={{ textDecoration: 'underline', cursor: 'pointer' }}
+                    >
+                      Shugo "FlowingSPDG" Kawamura
+                    </Link>
+                  }
+                  secondary="Original Creator & Developer - Created and developed vmix-utility"
+                />
+              </ListItem>
               <ListItem sx={{ pl: 0 }}>
                 <ListItemIcon>
                   <Avatar sx={{ bgcolor: 'primary.main' }}>

--- a/scraper/cmd/main.go
+++ b/scraper/cmd/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/FlowingSPDG/vmix-utility/scraper"
+	"github.com/Incomplete-Outputs-Lab/vmix-utility/scraper"
 )
 
 var (

--- a/scraper/go.mod
+++ b/scraper/go.mod
@@ -1,4 +1,4 @@
-module github.com/FlowingSPDG/vmix-utility/scraper
+module github.com/Incomplete-Outputs-Lab/vmix-utility/scraper
 
 go 1.24.0
 


### PR DESCRIPTION
## Summary
- Update all GitHub URLs from FlowingSPDG to Incomplete-Outputs-Lab
- Change developer attribution to 未完成成果物研究所
- Update Go module paths in scraper
- Update Tauri updater endpoint
- Add FlowingSPDG to Special Thanks section

## Changes
### Repository References
- Updated all GitHub URLs in README.md (badges, releases, issues)
- Updated updater endpoint in tauri.conf.json

### Developer Attribution
- Changed LICENSE copyright holder to 未完成成果物研究所
- Changed Cargo.toml authors to 未完成成果物研究所
- Updated Developer page to show 未完成成果物研究所 as maintainer
- Added Shugo "FlowingSPDG" Kawamura to Special Thanks section

### Module Paths
- Updated Go module path in scraper/go.mod
- Updated import path in scraper/cmd/main.go

## Test Plan
- [x] Application builds successfully with `bun run tauri dev`
- [x] Developer page displays correct information
- [x] All links function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)