### PR TITLE
fix: correct app version to 2.2.3

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app",
-  "version": "2.2.4",
+  "version": "2.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app",
-      "version": "2.2.4",
+      "version": "2.2.3",
       "dependencies": {
         "@babel/runtime": "^7.28.3",
         "@emotion/react": "^11.14.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "2.2.4",
+  "version": "2.2.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -114,7 +114,7 @@ checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "app"
-version = "2.2.4"
+version = "2.2.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "2.2.4"
+version = "2.2.3"
 description = "app"
 authors = ["未完成成果物研究所"]
 edition = "2024"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "vmix-utility",
-  "version": "2.2.4",
+  "version": "2.2.3",
   "identifier": "com.flowingspdg.vmix-utility",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
Replaces mistaken 2.2.4 with the intended 2.2.3 across package.json, package-lock.json, tauri.conf.json, Cargo.toml, and Cargo.lock.