### PR TITLE
feat: Windows NSIS/WiX installers and UX improvements

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -22,7 +22,7 @@ jobs:
           - platform: 'ubuntu-22.04'
             args: ''
           - platform: 'windows-latest'
-            args: '--target x86_64-pc-windows-msvc'
+            args: '--target x86_64-pc-windows-msvc --bundles msi,nsis'
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -117,8 +117,9 @@ jobs:
             
             ### Download Instructions
             Select the appropriate installer for your platform:
-            - **Windows**: `.msi` file
-            - **macOS**: `.dmg` file  
+            - **Windows**: `.msi` (WiX) or `-setup.exe` (NSIS)
+            - **macOS (Apple Silicon)**: `.dmg` for `aarch64-apple-darwin`
+            - **macOS (Intel)**: `.dmg` for `x86_64-apple-darwin`
             - **Linux**: `.AppImage` file
             
             ### How to Help

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           - platform: 'ubuntu-22.04'
             args: ''
           - platform: 'windows-latest'
-            args: '--target x86_64-pc-windows-msvc'
+            args: '--target x86_64-pc-windows-msvc --bundles msi,nsis'
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -79,8 +79,9 @@ jobs:
 
             ## Download
             Select the appropriate installer for your platform:
-            - **Windows**: `.msi` file
-            - **macOS**: `.dmg` file  
+            - **Windows**: `.msi` (WiX) or `-setup.exe` (NSIS)
+            - **macOS (Apple Silicon)**: `.dmg` for `aarch64-apple-darwin`
+            - **macOS (Intel)**: `.dmg` for `x86_64-apple-darwin`
             - **Linux**: `.AppImage` file
 
             ## Auto-Update

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -14,10 +14,12 @@ jobs:
         include:
           - platform: 'macos-latest'
             args: '--target aarch64-apple-darwin'
+          - platform: 'macos-latest'
+            args: '--target x86_64-apple-darwin'
           - platform: 'ubuntu-22.04'
             args: ''
           - platform: 'windows-latest'
-            args: ''
+            args: '--target x86_64-pc-windows-msvc --bundles msi,nsis'
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app",
   "private": true,
-  "version": "2.2.4",
+  "version": "2.2.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "2.2.4"
+version = "2.2.5"
 description = "app"
 authors = ["未完成成果物研究所"]
 edition = "2024"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -32,6 +32,14 @@
     "active": true,
     "targets": "all",
     "createUpdaterArtifacts": true,
+    "windows": {
+      "wix": {
+        "template": "./windows/main.wxs"
+      },
+      "nsis": {
+        "template": "./windows/installer.nsi"
+      }
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "vmix-utility",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "identifier": "com.flowingspdg.vmix-utility",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/app/src-tauri/tauri.windows.conf.json
+++ b/app/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,5 @@
+{
+  "bundle": {
+    "targets": ["msi", "nsis"]
+  }
+}

--- a/app/src-tauri/windows/installer.nsi
+++ b/app/src-tauri/windows/installer.nsi
@@ -1,0 +1,973 @@
+Unicode true
+ManifestDPIAware true
+; Add in `dpiAwareness` `PerMonitorV2` to manifest for Windows 10 1607+ (note this should not affect lower versions since they should be able to ignore this and pick up `dpiAware` `true` set by `ManifestDPIAware true`)
+; Currently undocumented on NSIS's website but is in the Docs folder of source tree, see
+; https://github.com/kichik/nsis/blob/5fc0b87b819a9eec006df4967d08e522ddd651c9/Docs/src/attributes.but#L286-L300
+; https://github.com/tauri-apps/tauri/pull/10106
+ManifestDPIAwareness PerMonitorV2
+
+!if "{{compression}}" == "none"
+  SetCompress off
+!else
+  ; Set the compression algorithm. We default to LZMA.
+  SetCompressor /SOLID "{{compression}}"
+!endif
+
+!include MUI2.nsh
+!include FileFunc.nsh
+!include x64.nsh
+!include WordFunc.nsh
+!include "utils.nsh"
+!include "FileAssociation.nsh"
+!include "Win\COM.nsh"
+!include "Win\Propkey.nsh"
+!include "StrFunc.nsh"
+${StrCase}
+${StrLoc}
+
+{{#if installer_hooks}}
+!include "{{installer_hooks}}"
+{{/if}}
+
+!define WEBVIEW2APPGUID "{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}"
+
+!define MANUFACTURER "{{manufacturer}}"
+!define PRODUCTNAME "{{product_name}}"
+!define VERSION "{{version}}"
+!define VERSIONWITHBUILD "{{version_with_build}}"
+!define HOMEPAGE "{{homepage}}"
+!define INSTALLMODE "{{install_mode}}"
+!define LICENSE "{{license}}"
+!define INSTALLERICON "{{installer_icon}}"
+!define SIDEBARIMAGE "{{sidebar_image}}"
+!define HEADERIMAGE "{{header_image}}"
+!define UNINSTALLERICON "{{uninstaller_icon}}"
+!define UNINSTALLERHEADERIMAGE "{{uninstaller_header_image}}"
+!define MAINBINARYNAME "{{main_binary_name}}"
+!define MAINBINARYSRCPATH "{{main_binary_path}}"
+!define BUNDLEID "{{bundle_id}}"
+!define COPYRIGHT "{{copyright}}"
+!define OUTFILE "{{out_file}}"
+!define ARCH "{{arch}}"
+!define ADDITIONALPLUGINSPATH "{{additional_plugins_path}}"
+!define ALLOWDOWNGRADES "{{allow_downgrades}}"
+!define DISPLAYLANGUAGESELECTOR "{{display_language_selector}}"
+!define INSTALLWEBVIEW2MODE "{{install_webview2_mode}}"
+!define WEBVIEW2INSTALLERARGS "{{webview2_installer_args}}"
+!define WEBVIEW2BOOTSTRAPPERPATH "{{webview2_bootstrapper_path}}"
+!define WEBVIEW2INSTALLERPATH "{{webview2_installer_path}}"
+!define MINIMUMWEBVIEW2VERSION "{{minimum_webview2_version}}"
+!define UNINSTKEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCTNAME}"
+!define MANUKEY "Software\${MANUFACTURER}"
+!define MANUPRODUCTKEY "${MANUKEY}\${PRODUCTNAME}"
+!define UNINSTALLERSIGNCOMMAND "{{uninstaller_sign_cmd}}"
+!define ESTIMATEDSIZE "{{estimated_size}}"
+!define STARTMENUFOLDER "{{start_menu_folder}}"
+
+Var PassiveMode
+Var UpdateMode
+Var NoShortcutMode
+Var WixMode
+Var OldMainBinaryName
+
+Name "${PRODUCTNAME}"
+BrandingText "${COPYRIGHT}"
+OutFile "${OUTFILE}"
+
+; We don't actually use this value as default install path,
+; it's just for nsis to append the product name folder in the directory selector
+; https://nsis.sourceforge.io/Reference/InstallDir
+!define INSTALL_PARENT_DIR "MikanseiLaboratory"
+!define INSTALL_RELATIVE_PATH "${INSTALL_PARENT_DIR}\${PRODUCTNAME}"
+!define PLACEHOLDER_INSTALL_DIR "placeholder\${INSTALL_RELATIVE_PATH}"
+InstallDir "${PLACEHOLDER_INSTALL_DIR}"
+
+VIProductVersion "${VERSIONWITHBUILD}"
+VIAddVersionKey "ProductName" "${PRODUCTNAME}"
+VIAddVersionKey "FileDescription" "${PRODUCTNAME}"
+VIAddVersionKey "LegalCopyright" "${COPYRIGHT}"
+VIAddVersionKey "FileVersion" "${VERSION}"
+VIAddVersionKey "ProductVersion" "${VERSION}"
+
+# additional plugins
+!addplugindir "${ADDITIONALPLUGINSPATH}"
+
+; Uninstaller signing command
+!if "${UNINSTALLERSIGNCOMMAND}" != ""
+  !uninstfinalize '${UNINSTALLERSIGNCOMMAND}'
+!endif
+
+; Handle install mode, `perUser`, `perMachine` or `both`
+!if "${INSTALLMODE}" == "perMachine"
+  RequestExecutionLevel admin
+!endif
+
+!if "${INSTALLMODE}" == "currentUser"
+  RequestExecutionLevel user
+!endif
+
+!if "${INSTALLMODE}" == "both"
+  !define MULTIUSER_MUI
+  !define MULTIUSER_INSTALLMODE_INSTDIR "${INSTALL_RELATIVE_PATH}"
+  !define MULTIUSER_INSTALLMODE_COMMANDLINE
+  !if "${ARCH}" == "x64"
+    !define MULTIUSER_USE_PROGRAMFILES64
+  !else if "${ARCH}" == "arm64"
+    !define MULTIUSER_USE_PROGRAMFILES64
+  !endif
+  !define MULTIUSER_INSTALLMODE_DEFAULT_REGISTRY_KEY "${UNINSTKEY}"
+  !define MULTIUSER_INSTALLMODE_DEFAULT_REGISTRY_VALUENAME "CurrentUser"
+  !define MULTIUSER_INSTALLMODEPAGE_SHOWUSERNAME
+  !define MULTIUSER_INSTALLMODE_FUNCTION RestorePreviousInstallLocation
+  !define MULTIUSER_EXECUTIONLEVEL Highest
+  !include MultiUser.nsh
+!endif
+
+; Installer icon
+!if "${INSTALLERICON}" != ""
+  !define MUI_ICON "${INSTALLERICON}"
+!endif
+
+; Installer sidebar image
+!if "${SIDEBARIMAGE}" != ""
+  !define MUI_WELCOMEFINISHPAGE_BITMAP "${SIDEBARIMAGE}"
+!endif
+
+; Enable header images for installer and uninstaller pages when either image is configured.
+!if "${HEADERIMAGE}" != ""
+  !define MUI_HEADERIMAGE
+!else if "${UNINSTALLERHEADERIMAGE}" != ""
+  !define MUI_HEADERIMAGE
+!endif
+
+; Installer header image
+!if "${HEADERIMAGE}" != ""
+  !define MUI_HEADERIMAGE_BITMAP "${HEADERIMAGE}"
+!endif
+
+; Uninstaller header image
+!if "${UNINSTALLERHEADERIMAGE}" != ""
+  !define MUI_HEADERIMAGE_UNBITMAP "${UNINSTALLERHEADERIMAGE}"
+!endif
+
+; Uninstaller icon
+!if "${UNINSTALLERICON}" != ""
+  !define MUI_UNICON "${UNINSTALLERICON}"
+!endif
+
+; Define registry key to store installer language
+!define MUI_LANGDLL_REGISTRY_ROOT "HKCU"
+!define MUI_LANGDLL_REGISTRY_KEY "${MANUPRODUCTKEY}"
+!define MUI_LANGDLL_REGISTRY_VALUENAME "Installer Language"
+
+; Installer pages, must be ordered as they appear
+; 1. Welcome Page
+!define MUI_PAGE_CUSTOMFUNCTION_PRE SkipIfPassive
+!insertmacro MUI_PAGE_WELCOME
+
+; 2. License Page (if defined)
+!if "${LICENSE}" != ""
+  !define MUI_PAGE_CUSTOMFUNCTION_PRE SkipIfPassive
+  !insertmacro MUI_PAGE_LICENSE "${LICENSE}"
+!endif
+
+; 3. Install mode (if it is set to `both`)
+!if "${INSTALLMODE}" == "both"
+  !define MUI_PAGE_CUSTOMFUNCTION_PRE SkipIfPassive
+  !insertmacro MULTIUSER_PAGE_INSTALLMODE
+!endif
+
+; 4. Custom page to ask user if he wants to reinstall/uninstall
+;    only if a previous installation was detected
+Var ReinstallPageCheck
+Page custom PageReinstall PageLeaveReinstall
+Function PageReinstall
+  ; Uninstall previous WiX installation if exists.
+  ;
+  ; A WiX installer stores the installation info in registry
+  ; using a UUID and so we have to loop through all keys under
+  ; `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall`
+  ; and check if `DisplayName` and `Publisher` keys match ${PRODUCTNAME} and ${MANUFACTURER}
+  ;
+  ; This has a potential issue that there maybe another installation that matches
+  ; our ${PRODUCTNAME} and ${MANUFACTURER} but wasn't installed by our WiX installer,
+  ; however, this should be fine since the user will have to confirm the uninstallation
+  ; and they can chose to abort it if doesn't make sense.
+  StrCpy $0 0
+  wix_loop:
+    EnumRegKey $1 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall" $0
+    StrCmp $1 "" wix_loop_done ; Exit loop if there is no more keys to loop on
+    IntOp $0 $0 + 1
+    ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$1" "DisplayName"
+    ReadRegStr $R1 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$1" "Publisher"
+    StrCmp "$R0$R1" "${PRODUCTNAME}${MANUFACTURER}" 0 wix_loop
+    ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$1" "UninstallString"
+    ${StrCase} $R1 $R0 "L"
+    ${StrLoc} $R0 $R1 "msiexec" ">"
+    StrCmp $R0 0 0 wix_loop_done
+    StrCpy $WixMode 1
+    StrCpy $R6 "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$1"
+    Goto compare_version
+  wix_loop_done:
+
+  ; Check if there is an existing installation, if not, abort the reinstall page
+  ReadRegStr $R0 SHCTX "${UNINSTKEY}" ""
+  ReadRegStr $R1 SHCTX "${UNINSTKEY}" "UninstallString"
+  ${IfThen} "$R0$R1" == "" ${|} Abort ${|}
+
+  ; Compare this installar version with the existing installation
+  ; and modify the messages presented to the user accordingly
+  compare_version:
+  StrCpy $R4 "$(older)"
+  ${If} $WixMode = 1
+    ReadRegStr $R0 HKLM "$R6" "DisplayVersion"
+  ${Else}
+    ReadRegStr $R0 SHCTX "${UNINSTKEY}" "DisplayVersion"
+  ${EndIf}
+  ${IfThen} $R0 == "" ${|} StrCpy $R4 "$(unknown)" ${|}
+
+  nsis_tauri_utils::SemverCompare "${VERSION}" $R0
+  Pop $R0
+  ; Reinstalling the same version
+  ${If} $R0 = 0
+    StrCpy $R1 "$(alreadyInstalledLong)"
+    StrCpy $R2 "$(addOrReinstall)"
+    StrCpy $R3 "$(uninstallApp)"
+    !insertmacro MUI_HEADER_TEXT "$(alreadyInstalled)" "$(chooseMaintenanceOption)"
+  ; Upgrading
+  ${ElseIf} $R0 = 1
+    StrCpy $R1 "$(olderOrUnknownVersionInstalled)"
+    StrCpy $R2 "$(uninstallBeforeInstalling)"
+    StrCpy $R3 "$(dontUninstall)"
+    !insertmacro MUI_HEADER_TEXT "$(alreadyInstalled)" "$(choowHowToInstall)"
+  ; Downgrading
+  ${ElseIf} $R0 = -1
+    StrCpy $R1 "$(newerVersionInstalled)"
+    StrCpy $R2 "$(uninstallBeforeInstalling)"
+    !if "${ALLOWDOWNGRADES}" == "true"
+      StrCpy $R3 "$(dontUninstall)"
+    !else
+      StrCpy $R3 "$(dontUninstallDowngrade)"
+    !endif
+    !insertmacro MUI_HEADER_TEXT "$(alreadyInstalled)" "$(choowHowToInstall)"
+  ${Else}
+    Abort
+  ${EndIf}
+
+  ; Skip showing the page if passive
+  ;
+  ; Note that we don't call this earlier at the begining
+  ; of this function because we need to populate some variables
+  ; related to current installed version if detected and whether
+  ; we are downgrading or not.
+  ${If} $PassiveMode = 1
+    Call PageLeaveReinstall
+  ${Else}
+    nsDialogs::Create 1018
+    Pop $R4
+    ${IfThen} $(^RTL) = 1 ${|} nsDialogs::SetRTL $(^RTL) ${|}
+
+    ${NSD_CreateLabel} 0 0 100% 24u $R1
+    Pop $R1
+
+    ${NSD_CreateRadioButton} 30u 50u -30u 8u $R2
+    Pop $R2
+    ${NSD_OnClick} $R2 PageReinstallUpdateSelection
+
+    ${NSD_CreateRadioButton} 30u 70u -30u 8u $R3
+    Pop $R3
+    ; Disable this radio button if downgrading and downgrades are disabled
+    !if "${ALLOWDOWNGRADES}" == "false"
+      ${IfThen} $R0 = -1 ${|} EnableWindow $R3 0 ${|}
+    !endif
+    ${NSD_OnClick} $R3 PageReinstallUpdateSelection
+
+    ; Check the first radio button if this the first time
+    ; we enter this page or if the second button wasn't
+    ; selected the last time we were on this page
+    ${If} $ReinstallPageCheck <> 2
+      SendMessage $R2 ${BM_SETCHECK} ${BST_CHECKED} 0
+    ${Else}
+      SendMessage $R3 ${BM_SETCHECK} ${BST_CHECKED} 0
+    ${EndIf}
+
+    ${NSD_SetFocus} $R2
+    nsDialogs::Show
+  ${EndIf}
+FunctionEnd
+Function PageReinstallUpdateSelection
+  ${NSD_GetState} $R2 $R1
+  ${If} $R1 == ${BST_CHECKED}
+    StrCpy $ReinstallPageCheck 1
+  ${Else}
+    StrCpy $ReinstallPageCheck 2
+  ${EndIf}
+FunctionEnd
+Function PageLeaveReinstall
+  ${NSD_GetState} $R2 $R1
+
+  ; If migrating from Wix, always uninstall
+  ${If} $WixMode = 1
+    Goto reinst_uninstall
+  ${EndIf}
+
+  ; In update mode, always proceeds without uninstalling
+  ${If} $UpdateMode = 1
+    Goto reinst_done
+  ${EndIf}
+
+  ; $R0 holds whether same(0)/upgrading(1)/downgrading(-1) version
+  ; $R1 holds the radio buttons state:
+  ;   1 => first choice was selected
+  ;   0 => second choice was selected
+  ${If} $R0 = 0 ; Same version, proceed
+    ${If} $R1 = 1              ; User chose to add/reinstall
+      Goto reinst_done
+    ${Else}                    ; User chose to uninstall
+      Goto reinst_uninstall
+    ${EndIf}
+  ${ElseIf} $R0 = 1 ; Upgrading
+    ${If} $R1 = 1              ; User chose to uninstall
+      Goto reinst_uninstall
+    ${Else}
+      Goto reinst_done         ; User chose NOT to uninstall
+    ${EndIf}
+  ${ElseIf} $R0 = -1 ; Downgrading
+    ${If} $R1 = 1              ; User chose to uninstall
+      Goto reinst_uninstall
+    ${Else}
+      Goto reinst_done         ; User chose NOT to uninstall
+    ${EndIf}
+  ${EndIf}
+
+  reinst_uninstall:
+    HideWindow
+    ClearErrors
+
+    ${If} $WixMode = 1
+      ReadRegStr $R1 HKLM "$R6" "UninstallString"
+      ExecWait '$R1' $0
+    ${Else}
+      ReadRegStr $4 SHCTX "${MANUPRODUCTKEY}" ""
+      ReadRegStr $R1 SHCTX "${UNINSTKEY}" "UninstallString"
+      ${IfThen} $UpdateMode = 1 ${|} StrCpy $R1 "$R1 /UPDATE" ${|} ; append /UPDATE
+      ${IfThen} $PassiveMode = 1 ${|} StrCpy $R1 "$R1 /P" ${|} ; append /P
+      StrCpy $R1 "$R1 _?=$4" ; append uninstall directory
+      ExecWait '$R1' $0
+    ${EndIf}
+
+    BringToFront
+
+    ${IfThen} ${Errors} ${|} StrCpy $0 2 ${|} ; ExecWait failed, set fake exit code
+
+    ${If} $0 <> 0
+    ${OrIf} ${FileExists} "$INSTDIR\${MAINBINARYNAME}.exe"
+      ; User cancelled wix uninstaller? return to select un/reinstall page
+      ${If} $WixMode = 1
+      ${AndIf} $0 = 1602
+        Abort
+      ${EndIf}
+
+      ; User cancelled NSIS uninstaller? return to select un/reinstall page
+      ${If} $0 = 1
+        Abort
+      ${EndIf}
+
+      ; Other erros? show generic error message and return to select un/reinstall page
+      MessageBox MB_ICONEXCLAMATION "$(unableToUninstall)"
+      Abort
+    ${EndIf}
+  reinst_done:
+FunctionEnd
+
+; 5. Choose install directory page
+!define MUI_PAGE_CUSTOMFUNCTION_PRE SkipIfPassive
+!insertmacro MUI_PAGE_DIRECTORY
+
+; 6. Start menu shortcut page
+Var AppStartMenuFolder
+!if "${STARTMENUFOLDER}" != ""
+  !define MUI_PAGE_CUSTOMFUNCTION_PRE SkipIfPassive
+  !define MUI_STARTMENUPAGE_DEFAULTFOLDER "${STARTMENUFOLDER}"
+!else
+  !define MUI_PAGE_CUSTOMFUNCTION_PRE Skip
+!endif
+!insertmacro MUI_PAGE_STARTMENU Application $AppStartMenuFolder
+
+; 7. Installation page
+!insertmacro MUI_PAGE_INSTFILES
+
+; 8. Finish page
+;
+; Don't auto jump to finish page after installation page,
+; because the installation page has useful info that can be used debug any issues with the installer.
+!define MUI_FINISHPAGE_NOAUTOCLOSE
+; Use show readme button in the finish page as a button create a desktop shortcut
+!define MUI_FINISHPAGE_SHOWREADME
+!define MUI_FINISHPAGE_SHOWREADME_TEXT "$(createDesktop)"
+!define MUI_FINISHPAGE_SHOWREADME_FUNCTION CreateOrUpdateDesktopShortcut
+; Show run app after installation.
+!define MUI_FINISHPAGE_RUN
+!define MUI_FINISHPAGE_RUN_FUNCTION RunMainBinary
+!define MUI_PAGE_CUSTOMFUNCTION_PRE SkipIfPassive
+!insertmacro MUI_PAGE_FINISH
+
+Function RunMainBinary
+  nsis_tauri_utils::RunAsUser "$INSTDIR\${MAINBINARYNAME}.exe" ""
+FunctionEnd
+
+; Uninstaller Pages
+; 1. Confirm uninstall page
+Var DeleteAppDataCheckbox
+Var DeleteAppDataCheckboxState
+!define /ifndef WS_EX_LAYOUTRTL         0x00400000
+!define MUI_PAGE_CUSTOMFUNCTION_SHOW un.ConfirmShow
+Function un.ConfirmShow ; Add add a `Delete app data` check box
+  ; $1 inner dialog HWND
+  ; $2 window DPI
+  ; $3 style
+  ; $4 x
+  ; $5 y
+  ; $6 width
+  ; $7 height
+  FindWindow $1 "#32770" "" $HWNDPARENT ; Find inner dialog
+  System::Call "user32::GetDpiForWindow(p r1) i .r2"
+  ${If} $(^RTL) = 1
+    StrCpy $3 "${__NSD_CheckBox_EXSTYLE} | ${WS_EX_LAYOUTRTL}"
+    IntOp $4 50 * $2
+  ${Else}
+    StrCpy $3 "${__NSD_CheckBox_EXSTYLE}"
+    IntOp $4 0 * $2
+  ${EndIf}
+  IntOp $5 100 * $2
+  IntOp $6 400 * $2
+  IntOp $7 25 * $2
+  IntOp $4 $4 / 96
+  IntOp $5 $5 / 96
+  IntOp $6 $6 / 96
+  IntOp $7 $7 / 96
+  System::Call 'user32::CreateWindowEx(i r3, w "${__NSD_CheckBox_CLASS}", w "$(deleteAppData)", i ${__NSD_CheckBox_STYLE}, i r4, i r5, i r6, i r7, p r1, i0, i0, i0) i .s'
+  Pop $DeleteAppDataCheckbox
+  SendMessage $HWNDPARENT ${WM_GETFONT} 0 0 $1
+  SendMessage $DeleteAppDataCheckbox ${WM_SETFONT} $1 1
+FunctionEnd
+!define MUI_PAGE_CUSTOMFUNCTION_LEAVE un.ConfirmLeave
+Function un.ConfirmLeave
+  SendMessage $DeleteAppDataCheckbox ${BM_GETCHECK} 0 0 $DeleteAppDataCheckboxState
+FunctionEnd
+!define MUI_PAGE_CUSTOMFUNCTION_PRE un.SkipIfPassive
+!insertmacro MUI_UNPAGE_CONFIRM
+
+; 2. Uninstalling Page
+!insertmacro MUI_UNPAGE_INSTFILES
+
+;Languages
+{{#each languages}}
+!insertmacro MUI_LANGUAGE "{{this}}"
+{{/each}}
+!insertmacro MUI_RESERVEFILE_LANGDLL
+{{#each language_files}}
+  !include "{{this}}"
+{{/each}}
+
+Function .onInit
+  ${GetOptions} $CMDLINE "/P" $PassiveMode
+  ${IfNot} ${Errors}
+    StrCpy $PassiveMode 1
+  ${EndIf}
+
+  ${GetOptions} $CMDLINE "/NS" $NoShortcutMode
+  ${IfNot} ${Errors}
+    StrCpy $NoShortcutMode 1
+  ${EndIf}
+
+  ${GetOptions} $CMDLINE "/UPDATE" $UpdateMode
+  ${IfNot} ${Errors}
+    StrCpy $UpdateMode 1
+  ${EndIf}
+
+  !if "${DISPLAYLANGUAGESELECTOR}" == "true"
+    !insertmacro MUI_LANGDLL_DISPLAY
+  !endif
+
+  !insertmacro SetContext
+
+  ${If} $INSTDIR == "${PLACEHOLDER_INSTALL_DIR}"
+    ; Set default install location
+    !if "${INSTALLMODE}" == "perMachine"
+      ${If} ${RunningX64}
+        !if "${ARCH}" == "x64"
+          StrCpy $INSTDIR "$PROGRAMFILES64\${INSTALL_RELATIVE_PATH}"
+        !else if "${ARCH}" == "arm64"
+          StrCpy $INSTDIR "$PROGRAMFILES64\${INSTALL_RELATIVE_PATH}"
+        !else
+          StrCpy $INSTDIR "$PROGRAMFILES\${INSTALL_RELATIVE_PATH}"
+        !endif
+      ${Else}
+        StrCpy $INSTDIR "$PROGRAMFILES\${INSTALL_RELATIVE_PATH}"
+      ${EndIf}
+    !else if "${INSTALLMODE}" == "currentUser"
+      StrCpy $INSTDIR "$LOCALAPPDATA\${INSTALL_RELATIVE_PATH}"
+    !endif
+
+    Call RestorePreviousInstallLocation
+  ${EndIf}
+
+
+  !if "${INSTALLMODE}" == "both"
+    !insertmacro MULTIUSER_INIT
+  !endif
+FunctionEnd
+
+
+Section EarlyChecks
+  ; Abort silent installer if downgrades is disabled
+  !if "${ALLOWDOWNGRADES}" == "false"
+  ${If} ${Silent}
+    ; If downgrading
+    ${If} $R0 = -1
+      System::Call 'kernel32::AttachConsole(i -1)i.r0'
+      ${If} $0 <> 0
+        System::Call 'kernel32::GetStdHandle(i -11)i.r0'
+        System::call 'kernel32::SetConsoleTextAttribute(i r0, i 0x0004)' ; set red color
+        FileWrite $0 "$(silentDowngrades)"
+      ${EndIf}
+      Abort
+    ${EndIf}
+  ${EndIf}
+  !endif
+
+SectionEnd
+
+Section WebView2
+  ; Check if Webview2 is already installed and skip this section
+  ${If} ${RunningX64}
+    ReadRegStr $4 HKLM "SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\${WEBVIEW2APPGUID}" "pv"
+  ${Else}
+    ReadRegStr $4 HKLM "SOFTWARE\Microsoft\EdgeUpdate\Clients\${WEBVIEW2APPGUID}" "pv"
+  ${EndIf}
+  ${If} $4 == ""
+    ReadRegStr $4 HKCU "SOFTWARE\Microsoft\EdgeUpdate\Clients\${WEBVIEW2APPGUID}" "pv"
+  ${EndIf}
+
+  ${If} $4 == ""
+    ; Webview2 installation
+    ;
+    ; Skip if updating
+    ${If} $UpdateMode <> 1
+      !if "${INSTALLWEBVIEW2MODE}" == "downloadBootstrapper"
+        Delete "$TEMP\MicrosoftEdgeWebview2Setup.exe"
+        DetailPrint "$(webview2Downloading)"
+        NSISdl::download "https://go.microsoft.com/fwlink/p/?LinkId=2124703" "$TEMP\MicrosoftEdgeWebview2Setup.exe"
+        Pop $0
+        ${If} $0 == "success"
+          DetailPrint "$(webview2DownloadSuccess)"
+        ${Else}
+          DetailPrint "$(webview2DownloadError)"
+          Abort "$(webview2AbortError)"
+        ${EndIf}
+        StrCpy $6 "$TEMP\MicrosoftEdgeWebview2Setup.exe"
+        Goto install_webview2
+      !endif
+
+      !if "${INSTALLWEBVIEW2MODE}" == "embedBootstrapper"
+        Delete "$TEMP\MicrosoftEdgeWebview2Setup.exe"
+        File "/oname=$TEMP\MicrosoftEdgeWebview2Setup.exe" "${WEBVIEW2BOOTSTRAPPERPATH}"
+        DetailPrint "$(installingWebview2)"
+        StrCpy $6 "$TEMP\MicrosoftEdgeWebview2Setup.exe"
+        Goto install_webview2
+      !endif
+
+      !if "${INSTALLWEBVIEW2MODE}" == "offlineInstaller"
+        Delete "$TEMP\MicrosoftEdgeWebView2RuntimeInstaller.exe"
+        File "/oname=$TEMP\MicrosoftEdgeWebView2RuntimeInstaller.exe" "${WEBVIEW2INSTALLERPATH}"
+        DetailPrint "$(installingWebview2)"
+        StrCpy $6 "$TEMP\MicrosoftEdgeWebView2RuntimeInstaller.exe"
+        Goto install_webview2
+      !endif
+
+      Goto webview2_done
+
+      install_webview2:
+        DetailPrint "$(installingWebview2)"
+        ; $6 holds the path to the webview2 installer
+        ExecWait "$6 ${WEBVIEW2INSTALLERARGS} /install" $1
+        ${If} $1 = 0
+          DetailPrint "$(webview2InstallSuccess)"
+        ${Else}
+          DetailPrint "$(webview2InstallError)"
+          Abort "$(webview2AbortError)"
+        ${EndIf}
+      webview2_done:
+    ${EndIf}
+  ${Else}
+    !if "${MINIMUMWEBVIEW2VERSION}" != ""
+      ${VersionCompare} "${MINIMUMWEBVIEW2VERSION}" "$4" $R0
+      ${If} $R0 = 1
+        update_webview:
+          DetailPrint "$(installingWebview2)"
+          ${If} ${RunningX64}
+            ReadRegStr $R1 HKLM "SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate" "path"
+          ${Else}
+            ReadRegStr $R1 HKLM "SOFTWARE\Microsoft\EdgeUpdate" "path"
+          ${EndIf}
+          ${If} $R1 == ""
+            ReadRegStr $R1 HKCU "SOFTWARE\Microsoft\EdgeUpdate" "path"
+          ${EndIf}
+          ${If} $R1 != ""
+            ; Chromium updater docs: https://source.chromium.org/chromium/chromium/src/+/main:docs/updater/user_manual.md
+            ; Modified from "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft EdgeWebView\ModifyPath"
+            ExecWait `"$R1" /install appguid=${WEBVIEW2APPGUID}&needsadmin=true` $1
+            ${If} $1 = 0
+              DetailPrint "$(webview2InstallSuccess)"
+            ${Else}
+              MessageBox MB_ICONEXCLAMATION|MB_ABORTRETRYIGNORE "$(webview2InstallError)" IDIGNORE ignore IDRETRY update_webview
+              Quit
+              ignore:
+            ${EndIf}
+          ${EndIf}
+      ${EndIf}
+    !endif
+  ${EndIf}
+SectionEnd
+
+Section Install
+  SetOutPath $INSTDIR
+
+  !ifmacrodef NSIS_HOOK_PREINSTALL
+    !insertmacro NSIS_HOOK_PREINSTALL
+  !endif
+
+  !insertmacro CheckIfAppIsRunning "${MAINBINARYNAME}.exe" "${PRODUCTNAME}"
+
+  ; Copy main executable
+  File "${MAINBINARYSRCPATH}"
+
+  ; Copy resources
+  {{#each resources_dirs}}
+    CreateDirectory "$INSTDIR\\{{this}}"
+  {{/each}}
+  {{#each resources}}
+    File /a "/oname={{this.[1]}}" "{{no-escape @key}}"
+  {{/each}}
+
+  ; Copy external binaries
+  {{#each binaries}}
+    File /a "/oname={{this}}" "{{no-escape @key}}"
+  {{/each}}
+
+  ; Create file associations
+  {{#each file_associations as |association| ~}}
+    {{#each association.ext as |ext| ~}}
+       !insertmacro APP_ASSOCIATE "{{ext}}" "{{or association.name ext}}" "{{association-description association.description ext}}" "$INSTDIR\${MAINBINARYNAME}.exe,0" "Open with ${PRODUCTNAME}" "$INSTDIR\${MAINBINARYNAME}.exe $\"%1$\""
+    {{/each}}
+  {{/each}}
+
+  ; Register deep links
+  {{#each deep_link_protocols as |protocol| ~}}
+    WriteRegStr SHCTX "Software\Classes\\{{protocol}}" "URL Protocol" ""
+    WriteRegStr SHCTX "Software\Classes\\{{protocol}}" "" "URL:${BUNDLEID} protocol"
+    WriteRegStr SHCTX "Software\Classes\\{{protocol}}\DefaultIcon" "" "$\"$INSTDIR\${MAINBINARYNAME}.exe$\",0"
+    WriteRegStr SHCTX "Software\Classes\\{{protocol}}\shell\open\command" "" "$\"$INSTDIR\${MAINBINARYNAME}.exe$\" $\"%1$\""
+  {{/each}}
+
+  ; Create uninstaller
+  WriteUninstaller "$INSTDIR\uninstall.exe"
+
+  ; Save $INSTDIR in registry for future installations
+  WriteRegStr SHCTX "${MANUPRODUCTKEY}" "" $INSTDIR
+
+  !if "${INSTALLMODE}" == "both"
+    ; Save install mode to be selected by default for the next installation such as updating
+    ; or when uninstalling
+    WriteRegStr SHCTX "${UNINSTKEY}" $MultiUser.InstallMode 1
+  !endif
+
+  ; Remove old main binary if it doesn't match new main binary name
+  ReadRegStr $OldMainBinaryName SHCTX "${UNINSTKEY}" "MainBinaryName"
+  ${If} $OldMainBinaryName != ""
+  ${AndIf} $OldMainBinaryName != "${MAINBINARYNAME}.exe"
+    Delete "$INSTDIR\$OldMainBinaryName"
+  ${EndIf}
+
+  ; Save current MAINBINARYNAME for future updates
+  WriteRegStr SHCTX "${UNINSTKEY}" "MainBinaryName" "${MAINBINARYNAME}.exe"
+
+  ; Registry information for add/remove programs
+  WriteRegStr SHCTX "${UNINSTKEY}" "DisplayName" "${PRODUCTNAME}"
+  WriteRegStr SHCTX "${UNINSTKEY}" "DisplayIcon" "$\"$INSTDIR\${MAINBINARYNAME}.exe$\""
+  WriteRegStr SHCTX "${UNINSTKEY}" "DisplayVersion" "${VERSION}"
+  WriteRegStr SHCTX "${UNINSTKEY}" "Publisher" "${MANUFACTURER}"
+  WriteRegStr SHCTX "${UNINSTKEY}" "InstallLocation" "$\"$INSTDIR$\""
+  WriteRegStr SHCTX "${UNINSTKEY}" "UninstallString" "$\"$INSTDIR\uninstall.exe$\""
+  WriteRegDWORD SHCTX "${UNINSTKEY}" "NoModify" "1"
+  WriteRegDWORD SHCTX "${UNINSTKEY}" "NoRepair" "1"
+
+  ${GetSize} "$INSTDIR" "/M=uninstall.exe /S=0K /G=0" $0 $1 $2
+  IntOp $0 $0 + ${ESTIMATEDSIZE}
+  IntFmt $0 "0x%08X" $0
+  WriteRegDWORD SHCTX "${UNINSTKEY}" "EstimatedSize" "$0"
+
+  !if "${HOMEPAGE}" != ""
+    WriteRegStr SHCTX "${UNINSTKEY}" "URLInfoAbout" "${HOMEPAGE}"
+    WriteRegStr SHCTX "${UNINSTKEY}" "URLUpdateInfo" "${HOMEPAGE}"
+    WriteRegStr SHCTX "${UNINSTKEY}" "HelpLink" "${HOMEPAGE}"
+  !endif
+
+  ; Create start menu shortcut
+  !insertmacro MUI_STARTMENU_WRITE_BEGIN Application
+    Call CreateOrUpdateStartMenuShortcut
+  !insertmacro MUI_STARTMENU_WRITE_END
+
+  ; Create desktop shortcut for silent and passive installers
+  ; because finish page will be skipped
+  ${If} $PassiveMode = 1
+  ${OrIf} ${Silent}
+    Call CreateOrUpdateDesktopShortcut
+  ${EndIf}
+
+  !ifmacrodef NSIS_HOOK_POSTINSTALL
+    !insertmacro NSIS_HOOK_POSTINSTALL
+  !endif
+
+  ; Auto close this page for passive mode
+  ${If} $PassiveMode = 1
+    SetAutoClose true
+  ${EndIf}
+SectionEnd
+
+Function .onInstSuccess
+  ; Check for `/R` flag only in silent and passive installers because
+  ; GUI installer has a toggle for the user to (re)start the app
+  ${If} $PassiveMode = 1
+  ${OrIf} ${Silent}
+    ${GetOptions} $CMDLINE "/R" $R0
+    ${IfNot} ${Errors}
+      ${GetOptions} $CMDLINE "/ARGS" $R0
+      nsis_tauri_utils::RunAsUser "$INSTDIR\${MAINBINARYNAME}.exe" "$R0"
+    ${EndIf}
+  ${EndIf}
+FunctionEnd
+
+Function un.onInit
+  !insertmacro SetContext
+
+  !if "${INSTALLMODE}" == "both"
+    !insertmacro MULTIUSER_UNINIT
+  !endif
+
+  !insertmacro MUI_UNGETLANGUAGE
+
+  ${GetOptions} $CMDLINE "/P" $PassiveMode
+  ${IfNot} ${Errors}
+    StrCpy $PassiveMode 1
+  ${EndIf}
+
+  ${GetOptions} $CMDLINE "/UPDATE" $UpdateMode
+  ${IfNot} ${Errors}
+    StrCpy $UpdateMode 1
+  ${EndIf}
+FunctionEnd
+
+Section Uninstall
+
+  !ifmacrodef NSIS_HOOK_PREUNINSTALL
+    !insertmacro NSIS_HOOK_PREUNINSTALL
+  !endif
+
+  !insertmacro CheckIfAppIsRunning "${MAINBINARYNAME}.exe" "${PRODUCTNAME}"
+
+  ; Delete the app directory and its content from disk
+  ; Copy main executable
+  Delete "$INSTDIR\${MAINBINARYNAME}.exe"
+
+  ; Delete resources
+  {{#each resources}}
+    Delete "$INSTDIR\\{{this.[1]}}"
+  {{/each}}
+
+  ; Delete external binaries
+  {{#each binaries}}
+    Delete "$INSTDIR\\{{this}}"
+  {{/each}}
+
+  ; Delete app associations
+  {{#each file_associations as |association| ~}}
+    {{#each association.ext as |ext| ~}}
+      !insertmacro APP_UNASSOCIATE "{{ext}}" "{{or association.name ext}}"
+    {{/each}}
+  {{/each}}
+
+  ; Delete deep links
+  {{#each deep_link_protocols as |protocol| ~}}
+    ReadRegStr $R7 SHCTX "Software\Classes\\{{protocol}}\shell\open\command" ""
+    ${If} $R7 == "$\"$INSTDIR\${MAINBINARYNAME}.exe$\" $\"%1$\""
+      DeleteRegKey SHCTX "Software\Classes\\{{protocol}}"
+    ${EndIf}
+  {{/each}}
+
+
+  ; Delete uninstaller
+  Delete "$INSTDIR\uninstall.exe"
+
+  {{#each resources_ancestors}}
+  RMDir /REBOOTOK "$INSTDIR\\{{this}}"
+  {{/each}}
+  RMDir "$INSTDIR"
+
+  ; Remove shortcuts if not updating
+  ${If} $UpdateMode <> 1
+    !insertmacro DeleteAppUserModelId
+
+    ; Remove start menu shortcut
+    !insertmacro MUI_STARTMENU_GETFOLDER Application $AppStartMenuFolder
+    !insertmacro IsShortcutTarget "$SMPROGRAMS\$AppStartMenuFolder\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe"
+    Pop $0
+    ${If} $0 = 1
+      !insertmacro UnpinShortcut "$SMPROGRAMS\$AppStartMenuFolder\${PRODUCTNAME}.lnk"
+      Delete "$SMPROGRAMS\$AppStartMenuFolder\${PRODUCTNAME}.lnk"
+      RMDir "$SMPROGRAMS\$AppStartMenuFolder"
+    ${EndIf}
+    !insertmacro IsShortcutTarget "$SMPROGRAMS\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe"
+    Pop $0
+    ${If} $0 = 1
+      !insertmacro UnpinShortcut "$SMPROGRAMS\${PRODUCTNAME}.lnk"
+      Delete "$SMPROGRAMS\${PRODUCTNAME}.lnk"
+    ${EndIf}
+
+    ; Remove desktop shortcuts
+    !insertmacro IsShortcutTarget "$DESKTOP\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe"
+    Pop $0
+    ${If} $0 = 1
+      !insertmacro UnpinShortcut "$DESKTOP\${PRODUCTNAME}.lnk"
+      Delete "$DESKTOP\${PRODUCTNAME}.lnk"
+    ${EndIf}
+  ${EndIf}
+
+  ; Remove registry information for add/remove programs
+  !if "${INSTALLMODE}" == "both"
+    DeleteRegKey SHCTX "${UNINSTKEY}"
+  !else if "${INSTALLMODE}" == "perMachine"
+    DeleteRegKey HKLM "${UNINSTKEY}"
+  !else
+    DeleteRegKey HKCU "${UNINSTKEY}"
+  !endif
+
+  ; Removes the Autostart entry for ${PRODUCTNAME} from the HKCU Run key if it exists.
+  ; This ensures the program does not launch automatically after uninstallation if it exists.
+  ; If it doesn't exist, it does nothing.
+  ; We do this when not updating (to preserve the registry value on updates)
+  ${If} $UpdateMode <> 1
+    DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Run" "${PRODUCTNAME}"
+  ${EndIf}
+
+  ; Delete app data if the checkbox is selected
+  ; and if not updating
+  ${If} $DeleteAppDataCheckboxState = 1
+  ${AndIf} $UpdateMode <> 1
+    ; Clear the install location $INSTDIR from registry
+    DeleteRegKey SHCTX "${MANUPRODUCTKEY}"
+    DeleteRegKey /ifempty SHCTX "${MANUKEY}"
+
+    ; Clear the install language from registry
+    DeleteRegValue HKCU "${MANUPRODUCTKEY}" "Installer Language"
+    DeleteRegKey /ifempty HKCU "${MANUPRODUCTKEY}"
+    DeleteRegKey /ifempty HKCU "${MANUKEY}"
+
+    SetShellVarContext current
+    RmDir /r "$APPDATA\${BUNDLEID}"
+    RmDir /r "$LOCALAPPDATA\${BUNDLEID}"
+  ${EndIf}
+
+  !ifmacrodef NSIS_HOOK_POSTUNINSTALL
+    !insertmacro NSIS_HOOK_POSTUNINSTALL
+  !endif
+
+  ; Auto close if passive mode or updating
+  ${If} $PassiveMode = 1
+  ${OrIf} $UpdateMode = 1
+    SetAutoClose true
+  ${EndIf}
+SectionEnd
+
+Function RestorePreviousInstallLocation
+  ReadRegStr $4 SHCTX "${MANUPRODUCTKEY}" ""
+  StrCmp $4 "" +2 0
+    StrCpy $INSTDIR $4
+FunctionEnd
+
+Function Skip
+  Abort
+FunctionEnd
+
+Function SkipIfPassive
+  ${IfThen} $PassiveMode = 1  ${|} Abort ${|}
+FunctionEnd
+Function un.SkipIfPassive
+  ${IfThen} $PassiveMode = 1  ${|} Abort ${|}
+FunctionEnd
+
+Function CreateOrUpdateStartMenuShortcut
+  ; We used to use product name as MAINBINARYNAME
+  ; migrate old shortcuts to target the new MAINBINARYNAME
+  StrCpy $R0 0
+
+  !insertmacro IsShortcutTarget "$SMPROGRAMS\$AppStartMenuFolder\${PRODUCTNAME}.lnk" "$INSTDIR\$OldMainBinaryName"
+  Pop $0
+  ${If} $0 = 1
+    !insertmacro SetShortcutTarget "$SMPROGRAMS\$AppStartMenuFolder\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe"
+    StrCpy $R0 1
+  ${EndIf}
+
+  !insertmacro IsShortcutTarget "$SMPROGRAMS\${PRODUCTNAME}.lnk" "$INSTDIR\$OldMainBinaryName"
+  Pop $0
+  ${If} $0 = 1
+    !insertmacro SetShortcutTarget "$SMPROGRAMS\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe"
+    StrCpy $R0 1
+  ${EndIf}
+
+  ${If} $R0 = 1
+    Return
+  ${EndIf}
+
+  ; Skip creating shortcut if in update mode or no shortcut mode
+  ; but always create if migrating from wix
+  ${If} $WixMode = 0
+    ${If} $UpdateMode = 1
+    ${OrIf} $NoShortcutMode = 1
+      Return
+    ${EndIf}
+  ${EndIf}
+
+  !if "${STARTMENUFOLDER}" != ""
+    CreateDirectory "$SMPROGRAMS\$AppStartMenuFolder"
+    CreateShortcut "$SMPROGRAMS\$AppStartMenuFolder\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe"
+    !insertmacro SetLnkAppUserModelId "$SMPROGRAMS\$AppStartMenuFolder\${PRODUCTNAME}.lnk"
+  !else
+    CreateShortcut "$SMPROGRAMS\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe"
+    !insertmacro SetLnkAppUserModelId "$SMPROGRAMS\${PRODUCTNAME}.lnk"
+  !endif
+FunctionEnd
+
+Function CreateOrUpdateDesktopShortcut
+  ; We used to use product name as MAINBINARYNAME
+  ; migrate old shortcuts to target the new MAINBINARYNAME
+  !insertmacro IsShortcutTarget "$DESKTOP\${PRODUCTNAME}.lnk" "$INSTDIR\$OldMainBinaryName"
+  Pop $0
+  ${If} $0 = 1
+    !insertmacro SetShortcutTarget "$DESKTOP\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe"
+    Return
+  ${EndIf}
+
+  ; Skip creating shortcut if in update mode or no shortcut mode
+  ; but always create if migrating from wix
+  ${If} $WixMode = 0
+    ${If} $UpdateMode = 1
+    ${OrIf} $NoShortcutMode = 1
+      Return
+    ${EndIf}
+  ${EndIf}
+
+  CreateShortcut "$DESKTOP\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe"
+  !insertmacro SetLnkAppUserModelId "$DESKTOP\${PRODUCTNAME}.lnk"
+FunctionEnd

--- a/app/src-tauri/windows/main.wxs
+++ b/app/src-tauri/windows/main.wxs
@@ -1,0 +1,383 @@
+<?if $(sys.BUILDARCH)="x86"?>
+    <?define Win64 = "no" ?>
+    <?define PlatformProgramFilesFolder = "ProgramFilesFolder" ?>
+<?elseif $(sys.BUILDARCH)="x64"?>
+    <?define Win64 = "yes" ?>
+    <?define PlatformProgramFilesFolder = "ProgramFiles64Folder" ?>
+<?elseif $(sys.BUILDARCH)="arm64"?>
+    <?define Win64 = "yes" ?>
+    <?define PlatformProgramFilesFolder = "ProgramFiles64Folder" ?>
+<?else?>
+    <?error Unsupported value of sys.BUILDARCH=$(sys.BUILDARCH)?>
+<?endif?>
+
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Product
+            Id="*"
+            Name="{{product_name}}"
+            UpgradeCode="{{upgrade_code}}"
+            Language="!(loc.TauriLanguage)"
+            Manufacturer="{{manufacturer}}"
+            Version="{{version}}">
+
+        <Package Id="*"
+                 Keywords="Installer"
+                 InstallerVersion="450"
+                 Languages="0"
+                 Compressed="yes"
+                 InstallScope="perMachine"
+                 SummaryCodepage="!(loc.TauriCodepage)"/>
+
+        <!-- https://docs.microsoft.com/en-us/windows/win32/msi/reinstallmode -->
+        <!-- reinstall all files; rewrite all registry entries; reinstall all shortcuts -->
+        <Property Id="REINSTALLMODE" Value="amus" />
+
+        <!-- Auto launch app after installation, useful for passive mode which usually used in updates -->
+        <Property Id="AUTOLAUNCHAPP" Secure="yes" />
+        <!-- Property to forward cli args to the launched app to not lose those of the pre-update instance -->
+        <Property Id="LAUNCHAPPARGS" Secure="yes" />
+
+        {{#if allow_downgrades}}
+            <MajorUpgrade Schedule="afterInstallInitialize" AllowDowngrades="yes" />
+        {{else}}
+            <MajorUpgrade Schedule="afterInstallInitialize" DowngradeErrorMessage="!(loc.DowngradeErrorMessage)" AllowSameVersionUpgrades="yes" />
+        {{/if}}
+
+        <InstallExecuteSequence>
+            <RemoveShortcuts>Installed AND NOT UPGRADINGPRODUCTCODE</RemoveShortcuts>
+        </InstallExecuteSequence>
+
+        <Media Id="1" Cabinet="app.cab" EmbedCab="yes" />
+
+        {{#if banner_path}}
+        <WixVariable Id="WixUIBannerBmp" Value="{{banner_path}}" />
+        {{/if}}
+        {{#if dialog_image_path}}
+        <WixVariable Id="WixUIDialogBmp" Value="{{dialog_image_path}}" />
+        {{/if}}
+        {{#if license}}
+        <WixVariable Id="WixUILicenseRtf" Value="{{license}}" />
+        {{/if}}
+
+        <Icon Id="ProductIcon" SourceFile="{{icon_path}}"/>
+        <Property Id="ARPPRODUCTICON" Value="ProductIcon" />
+        <Property Id="ARPNOREPAIR" Value="yes" Secure="yes" />      <!-- Remove repair -->
+        <SetProperty Id="ARPNOMODIFY" Value="1" After="InstallValidate" Sequence="execute"/>
+
+        {{#if homepage}}
+        <Property Id="ARPURLINFOABOUT" Value="{{homepage}}"/>
+        <Property Id="ARPHELPLINK" Value="{{homepage}}"/>
+        <Property Id="ARPURLUPDATEINFO" Value="{{homepage}}"/>
+        {{/if}}
+
+        <!-- NOTE: The order of RegistrySearch elements below matters. In WIX, when multiple
+             RegistrySearch elements are listed under a single Property, the LAST successful
+             match wins. We list the NSIS default-key search first and the MSI InstallDir
+             search second so that the MSI-specific path takes priority when both keys exist. -->
+        <Property Id="INSTALLDIR">
+          <!-- First attempt: Search for the default key value (this is how the nsis installer stores the path) -->
+          <RegistrySearch Id="PrevInstallDirNoName" Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Type="raw" />
+
+          <!-- Second attempt: Search for "InstallDir" which takes priority if found (this is how the msi installer stores the path) -->
+          <RegistrySearch Id="PrevInstallDirWithName" Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Name="InstallDir" Type="raw" />
+        </Property>
+
+        <!-- launch app checkbox -->
+        <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="!(loc.LaunchApp)" />
+        <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" Value="1"/>
+        <CustomAction Id="LaunchApplication" Impersonate="yes" FileKey="Path" ExeCommand="[LAUNCHAPPARGS]" Return="asyncNoWait" />
+
+        <UI>
+            <!-- launch app checkbox -->
+            <Publish Dialog="ExitDialog" Control="Finish" Event="DoAction" Value="LaunchApplication">WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 and NOT Installed</Publish>
+
+            <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
+
+            {{#unless license}}
+            <!-- Skip license dialog -->
+            <Publish Dialog="WelcomeDlg"
+                     Control="Next"
+                     Event="NewDialog"
+                     Value="InstallDirDlg"
+                     Order="2">1</Publish>
+            <Publish Dialog="InstallDirDlg"
+                     Control="Back"
+                     Event="NewDialog"
+                     Value="WelcomeDlg"
+                     Order="2">1</Publish>
+            {{/unless}}
+        </UI>
+
+        <UIRef Id="WixUI_InstallDir" />
+
+        <Directory Id="TARGETDIR" Name="SourceDir">
+            <Directory Id="DesktopFolder" Name="Desktop">
+                <Component Id="ApplicationShortcutDesktop" Guid="*">
+                    <Shortcut Id="ApplicationDesktopShortcut" Name="{{product_name}}" Description="Runs {{product_name}}" Target="[!Path]" WorkingDirectory="INSTALLDIR" />
+                    <RemoveFolder Id="DesktopFolder" On="uninstall" />
+                    <RegistryValue Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Name="Desktop Shortcut" Type="integer" Value="1" KeyPath="yes" />
+                </Component>
+            </Directory>
+            <Directory Id="$(var.PlatformProgramFilesFolder)" Name="PFiles">
+                <Directory Id="MikanseiLaboratoryDir" Name="MikanseiLaboratory">
+                    <Directory Id="INSTALLDIR" Name="{{product_name}}"/>
+                </Directory>
+            </Directory>
+            <Directory Id="ProgramMenuFolder">
+                <Directory Id="ApplicationProgramsFolder" Name="{{product_name}}"/>
+            </Directory>
+        </Directory>
+
+        <DirectoryRef Id="INSTALLDIR">
+            <Component Id="RegistryEntries" Guid="*">
+                <RegistryKey Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}">
+                    <RegistryValue Name="InstallDir" Type="string" Value="[INSTALLDIR]" KeyPath="yes" />
+                </RegistryKey>
+                <!-- Change the Root to HKCU for perUser installations -->
+                {{#each deep_link_protocols as |protocol| ~}}
+                <RegistryKey Root="HKLM" Key="Software\Classes\\{{protocol}}">
+                    <RegistryValue Type="string" Name="URL Protocol" Value=""/>
+                    <RegistryValue Type="string" Value="URL:{{bundle_id}} protocol"/>
+                    <RegistryKey Key="DefaultIcon">
+                        <RegistryValue Type="string" Value="&quot;[!Path]&quot;,0" />
+                    </RegistryKey>
+                    <RegistryKey Key="shell\open\command">
+                        <RegistryValue Type="string" Value="&quot;[!Path]&quot; &quot;%1&quot;" />
+                    </RegistryKey>
+                </RegistryKey>
+                {{/each~}}
+            </Component>
+            <Component Id="Path" Guid="{{path_component_guid}}" Win64="$(var.Win64)">
+                <File Id="Path" Source="{{main_binary_path}}" KeyPath="yes" Checksum="yes"/>
+                {{#each file_associations as |association| ~}}
+                {{#each association.ext as |ext| ~}}
+                <ProgId Id="{{../../product_name}}.{{ext}}" Advertise="yes" Description="{{association.description}}">
+                    <Extension Id="{{ext}}" Advertise="yes">
+                        <Verb Id="open" Command="Open with {{../../product_name}}" Argument="&quot;%1&quot;" />
+                    </Extension>
+                </ProgId>
+                {{/each~}}
+                {{/each~}}
+            </Component>
+            {{#each binaries as |bin| ~}}
+            <Component Id="{{ bin.id }}" Guid="{{bin.guid}}" Win64="$(var.Win64)">
+                <File Id="Bin_{{ bin.id }}" Source="{{bin.path}}" KeyPath="yes"/>
+            </Component>
+            {{/each~}}
+            {{#if enable_elevated_update_task}}
+            <Component Id="UpdateTask" Guid="C492327D-9720-4CD5-8DB8-F09082AF44BE" Win64="$(var.Win64)">
+                <File Id="UpdateTask" Source="update.xml" KeyPath="yes" Checksum="yes"/>
+            </Component>
+            <Component Id="UpdateTaskInstaller" Guid="011F25ED-9BE3-50A7-9E9B-3519ED2B9932" Win64="$(var.Win64)">
+                <File Id="UpdateTaskInstaller" Source="install-task.ps1" KeyPath="yes" Checksum="yes"/>
+            </Component>
+            <Component Id="UpdateTaskUninstaller" Guid="D4F6CC3F-32DC-5FD0-95E8-782FFD7BBCE1" Win64="$(var.Win64)">
+                <File Id="UpdateTaskUninstaller" Source="uninstall-task.ps1" KeyPath="yes" Checksum="yes"/>
+            </Component>
+            {{/if}}
+            {{resources}}
+            <Component Id="CMP_UninstallShortcut" Guid="*">
+
+                <Shortcut Id="UninstallShortcut"
+						  Name="Uninstall {{product_name}}"
+						  Description="Uninstalls {{product_name}}"
+						  Target="[System64Folder]msiexec.exe"
+						  Arguments="/x [ProductCode]" />
+
+				<RemoveFolder Id="INSTALLDIR"
+							  On="uninstall" />
+
+				<RegistryValue Root="HKCU"
+							   Key="Software\\{{manufacturer}}\\{{product_name}}"
+							   Name="Uninstaller Shortcut"
+							   Type="integer"
+							   Value="1"
+							   KeyPath="yes" />
+            </Component>
+        </DirectoryRef>
+
+        <DirectoryRef Id="ApplicationProgramsFolder">
+            <Component Id="ApplicationShortcut" Guid="*">
+                <Shortcut Id="ApplicationStartMenuShortcut"
+                    Name="{{product_name}}"
+                    Description="Runs {{product_name}}"
+                    Target="[!Path]"
+                    Icon="ProductIcon"
+                    WorkingDirectory="INSTALLDIR">
+                    <ShortcutProperty Key="System.AppUserModel.ID" Value="{{bundle_id}}"/>
+                </Shortcut>
+                <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
+                <RegistryValue Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Name="Start Menu Shortcut" Type="integer" Value="1" KeyPath="yes"/>
+           </Component>
+        </DirectoryRef>
+
+        {{#each merge_modules as |msm| ~}}
+        <DirectoryRef Id="TARGETDIR">
+            <Merge Id="{{ msm.name }}" SourceFile="{{ msm.path }}" DiskId="1" Language="!(loc.TauriLanguage)" />
+        </DirectoryRef>
+
+        <Feature Id="{{ msm.name }}" Title="{{ msm.name }}" AllowAdvertise="no" Display="hidden" Level="1">
+            <MergeRef Id="{{ msm.name }}"/>
+        </Feature>
+        {{/each~}}
+
+        <Feature
+                Id="MainProgram"
+                Title="Application"
+                Description="!(loc.InstallAppFeature)"
+                Level="1"
+                ConfigurableDirectory="INSTALLDIR"
+                AllowAdvertise="no"
+                Display="expand"
+                Absent="disallow">
+
+            <ComponentRef Id="RegistryEntries"/>
+
+            {{#each resource_file_ids as |resource_file_id| ~}}
+                <ComponentRef Id="{{ resource_file_id }}"/>
+            {{/each~}}
+
+            {{#if enable_elevated_update_task}}
+                <ComponentRef Id="UpdateTask" />
+                <ComponentRef Id="UpdateTaskInstaller" />
+                <ComponentRef Id="UpdateTaskUninstaller" />
+            {{/if}}
+
+            <Feature Id="ShortcutsFeature"
+                Title="Shortcuts"
+                Level="1">
+                <ComponentRef Id="Path"/>
+                <ComponentRef Id="CMP_UninstallShortcut" />
+                <ComponentRef Id="ApplicationShortcut" />
+                <ComponentRef Id="ApplicationShortcutDesktop" />
+            </Feature>
+
+            <Feature
+                Id="Environment"
+                Title="PATH Environment Variable"
+                Description="!(loc.PathEnvVarFeature)"
+                Level="1"
+                Absent="allow">
+            <ComponentRef Id="Path"/>
+            {{#each binaries as |bin| ~}}
+            <ComponentRef Id="{{ bin.id }}"/>
+            {{/each~}}
+            </Feature>
+        </Feature>
+
+        <Feature Id="External" AllowAdvertise="no" Absent="disallow">
+            {{#each component_group_refs as |id| ~}}
+            <ComponentGroupRef Id="{{ id }}"/>
+            {{/each~}}
+            {{#each component_refs as |id| ~}}
+            <ComponentRef Id="{{ id }}"/>
+            {{/each~}}
+            {{#each feature_group_refs as |id| ~}}
+            <FeatureGroupRef Id="{{ id }}"/>
+            {{/each~}}
+            {{#each feature_refs as |id| ~}}
+            <FeatureRef Id="{{ id }}"/>
+            {{/each~}}
+            {{#each merge_refs as |id| ~}}
+            <MergeRef Id="{{ id }}"/>
+            {{/each~}}
+        </Feature>
+
+        {{#if install_webview}}
+        <!-- WebView2 -->
+        <Property Id="INSTALLED_WEBVIEW2_VERSION">
+            <RegistrySearch Id="Webview2VersionSystemx64" Root="HKLM" Key="SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" Name="pv" Type="raw" />
+            <RegistrySearch Id="Webview2VersionSystemx86" Root="HKLM" Key="SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" Name="pv" Type="raw" />
+            <RegistrySearch Id="Webview2VersionUser" Root="HKCU" Key="SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" Name="pv" Type="raw"/>
+        </Property>
+
+        {{#if download_bootstrapper}}
+        <!-- Download webview bootstrapper mode -->
+        <CustomAction Id='DownloadAndInvokeBootstrapper' Directory="INSTALLDIR" Execute="deferred" ExeCommand='powershell.exe -NoProfile -windowstyle hidden try [\{] [\[]Net.ServicePointManager[\]]::SecurityProtocol = [\[]Net.SecurityProtocolType[\]]::Tls12 [\}] catch [\{][\}]; Invoke-WebRequest -Uri "https://go.microsoft.com/fwlink/p/?LinkId=2124703" -OutFile "$env:TEMP\MicrosoftEdgeWebview2Setup.exe" ; Start-Process -FilePath "$env:TEMP\MicrosoftEdgeWebview2Setup.exe" -ArgumentList ({{webview_installer_args}} &apos;/install&apos;) -Wait' Return='check'/>
+        <InstallExecuteSequence>
+            <Custom Action='DownloadAndInvokeBootstrapper' Before='InstallFinalize'>
+                <![CDATA[NOT(REMOVE OR INSTALLED_WEBVIEW2_VERSION)]]>
+            </Custom>
+        </InstallExecuteSequence>
+        {{/if}}
+
+        {{#if webview2_bootstrapper_path}}
+        <!-- Embedded webview bootstrapper mode -->
+        <Binary Id="MicrosoftEdgeWebview2Setup.exe" SourceFile="{{webview2_bootstrapper_path}}"/>
+        <CustomAction Id='InvokeBootstrapper' BinaryKey='MicrosoftEdgeWebview2Setup.exe' Execute="deferred" ExeCommand='{{webview_installer_args}} /install' Return='check' />
+        <InstallExecuteSequence>
+            <Custom Action='InvokeBootstrapper' Before='InstallFinalize'>
+                <![CDATA[NOT(REMOVE OR INSTALLED_WEBVIEW2_VERSION)]]>
+            </Custom>
+        </InstallExecuteSequence>
+        {{/if}}
+
+        {{#if webview2_installer_path}}
+        <!-- Embedded offline installer -->
+        <Binary Id="MicrosoftEdgeWebView2RuntimeInstaller.exe" SourceFile="{{webview2_installer_path}}"/>
+        <CustomAction Id='InvokeStandalone' BinaryKey='MicrosoftEdgeWebView2RuntimeInstaller.exe' Execute="deferred" ExeCommand='{{webview_installer_args}} /install' Return='check' />
+        <InstallExecuteSequence>
+            <Custom Action='InvokeStandalone' Before='InstallFinalize'>
+                <![CDATA[NOT(REMOVE OR INSTALLED_WEBVIEW2_VERSION)]]>
+            </Custom>
+        </InstallExecuteSequence>
+        {{/if}}
+
+        {{#if minimum_webview2_version}}
+        <!-- Update WebView2 if minimum version requirement not met -->
+        <Property Id="MINIMUM_WEBVIEW2_VERSION" Value="{{minimum_webview2_version}}" />
+        <Property Id="EDGEUPDATE_PATH">
+            <RegistrySearch Id="EdgeUpdateLocalMachine64" Root="HKLM" Key="SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate" Name="path" Type="raw" />
+            <RegistrySearch Id="EdgeUpdateLocalMachine32" Root="HKLM" Key="SOFTWARE\Microsoft\EdgeUpdate" Name="path" Type="raw"/>
+            <RegistrySearch Id="EdgeUpdateCurrentUser" Root="HKCU" Key="SOFTWARE\Microsoft\EdgeUpdate" Name="path" Type="raw"/>
+        </Property>
+        <!-- Chromium updater docs: https://source.chromium.org/chromium/chromium/src/+/main:docs/updater/user_manual.md -->
+        <!-- Modified from "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft EdgeWebView\ModifyPath" -->
+        <CustomAction Id="UpdateWebView2ViaEdgeUpdate" Execute="deferred" Property="EDGEUPDATE_PATH" Return="check" Impersonate="no" ExeCommand="/install appguid={F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}&amp;needsadmin=true" />
+        <InstallExecuteSequence>
+            <Custom Action='UpdateWebView2ViaEdgeUpdate' Before='InstallFinalize'>
+                <![CDATA[
+                  NOT REMOVE
+                  AND INSTALLED_WEBVIEW2_VERSION
+                  AND (INSTALLED_WEBVIEW2_VERSION < MINIMUM_WEBVIEW2_VERSION)
+                ]]>
+            </Custom>
+        </InstallExecuteSequence>
+        {{/if}}
+
+        {{/if}}
+
+        {{#if enable_elevated_update_task}}
+        <!-- Install an elevated update task within Windows Task Scheduler -->
+        <CustomAction
+            Id="CreateUpdateTask"
+            Return="check"
+            Directory="INSTALLDIR"
+            Execute="commit"
+            Impersonate="yes"
+            ExeCommand="powershell.exe -WindowStyle hidden .\install-task.ps1" />
+        <InstallExecuteSequence>
+            <Custom Action='CreateUpdateTask' Before='InstallFinalize'>
+                NOT(REMOVE)
+            </Custom>
+        </InstallExecuteSequence>
+        <!-- Remove elevated update task during uninstall -->
+        <CustomAction
+            Id="DeleteUpdateTask"
+            Return="check"
+            Directory="INSTALLDIR"
+            ExeCommand="powershell.exe -WindowStyle hidden .\uninstall-task.ps1" />
+        <InstallExecuteSequence>
+            <Custom Action="DeleteUpdateTask" Before='InstallFinalize'>
+                (REMOVE = "ALL") AND NOT UPGRADINGPRODUCTCODE
+            </Custom>
+        </InstallExecuteSequence>
+        {{/if}}
+
+        <InstallExecuteSequence>
+          <Custom Action="LaunchApplication" After="InstallFinalize">AUTOLAUNCHAPP AND NOT Installed</Custom>
+        </InstallExecuteSequence>
+
+        <SetProperty Id="ARPINSTALLLOCATION" Value="[INSTALLDIR]" After="CostFinalize"/>
+    </Product>
+</Wix>

--- a/app/src/components/DonationDialog.tsx
+++ b/app/src/components/DonationDialog.tsx
@@ -8,7 +8,7 @@ import DialogTitle from '@mui/material/DialogTitle';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import SvgIcon, { type SvgIconProps } from '@mui/material/SvgIcon';
 import Typography from '@mui/material/Typography';
-import { FavoriteOutlined } from '@mui/icons-material';
+import FavoriteOutlinedIcon from '@mui/icons-material/FavoriteOutlined';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { useState } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
@@ -45,7 +45,7 @@ const DonationDialog = ({ open, onClose }: DonationDialogProps) => {
     >
       <DialogTitle>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <FavoriteOutlined color="error" />
+          <FavoriteOutlinedIcon color="error" />
           <span>{t('donation.title')}</span>
         </Box>
       </DialogTitle>

--- a/app/src/components/Layout.tsx
+++ b/app/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useMemo, useState, type LazyExoticComponent, type ComponentType, type ReactElement } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useMemo, useState, type LazyExoticComponent, type ComponentType, type ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Drawer from '@mui/material/Drawer';
@@ -25,13 +25,23 @@ import PlaylistPlayIcon from '@mui/icons-material/PlaylistPlay';
 import SettingsIcon from '@mui/icons-material/Settings';
 import CodeIcon from '@mui/icons-material/Code';
 
-const Connections = lazy(() => import('../pages/Connections'));
-const ShortcutGenerator = lazy(() => import('../pages/ShortcutGenerator'));
-const BlankGenerator = lazy(() => import('../pages/BlankGenerator'));
-const InputManager = lazy(() => import('../pages/InputManager'));
-const ListManager = lazy(() => import('../pages/ListManager'));
-const Settings = lazy(() => import('../pages/Settings'));
-const Developer = lazy(() => import('../pages/Developer'));
+const pageModules = {
+  connections: () => import('../pages/Connections'),
+  shortcutGenerator: () => import('../pages/ShortcutGenerator'),
+  blankGenerator: () => import('../pages/BlankGenerator'),
+  inputManager: () => import('../pages/InputManager'),
+  listManager: () => import('../pages/ListManager'),
+  settings: () => import('../pages/Settings'),
+  developer: () => import('../pages/Developer'),
+} as const;
+
+const Connections = lazy(pageModules.connections);
+const ShortcutGenerator = lazy(pageModules.shortcutGenerator);
+const BlankGenerator = lazy(pageModules.blankGenerator);
+const InputManager = lazy(pageModules.inputManager);
+const ListManager = lazy(pageModules.listManager);
+const Settings = lazy(pageModules.settings);
+const Developer = lazy(pageModules.developer);
 
 const drawerWidth = 240;
 
@@ -39,6 +49,7 @@ interface NavItem {
   text: string;
   icon: ReactElement;
   Page: LazyExoticComponent<ComponentType>;
+  preload: () => Promise<unknown>;
 }
 
 const Layout = () => {
@@ -46,6 +57,7 @@ const Layout = () => {
   const [mobileOpen, setMobileOpen] = useState(false);
   const [desktopOpen, setDesktopOpen] = useState(true);
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [visitedPages, setVisitedPages] = useState<Set<number>>(() => new Set([0]));
 
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -58,43 +70,71 @@ const Layout = () => {
     }
   };
 
+  const preloadPage = useCallback((preload: () => Promise<unknown>) => {
+    void preload();
+  }, []);
+
   const navItems: NavItem[] = useMemo(() => [
     {
       text: t('layout.nav.connections'),
       icon: <LinkIcon />,
       Page: Connections,
+      preload: pageModules.connections,
     },
     {
       text: t('layout.nav.shortcutGenerator'),
       icon: <ShortcutIcon />,
       Page: ShortcutGenerator,
+      preload: pageModules.shortcutGenerator,
     },
     {
       text: t('layout.nav.blankGenerator'),
       icon: <CreateIcon />,
       Page: BlankGenerator,
+      preload: pageModules.blankGenerator,
     },
     {
       text: t('layout.nav.inputManager'),
       icon: <ViewListIcon />,
       Page: InputManager,
+      preload: pageModules.inputManager,
     },
     {
       text: t('layout.nav.listManager'),
       icon: <PlaylistPlayIcon />,
       Page: ListManager,
+      preload: pageModules.listManager,
     },
     {
       text: t('layout.nav.settings'),
       icon: <SettingsIcon />,
       Page: Settings,
+      preload: pageModules.settings,
     },
     {
       text: t('layout.nav.about'),
       icon: <CodeIcon />,
       Page: Developer,
+      preload: pageModules.developer,
     },
   ], [t]);
+
+  useEffect(() => {
+    setVisitedPages(prev => {
+      if (prev.has(selectedIndex)) {
+        return prev;
+      }
+      const next = new Set(prev);
+      next.add(selectedIndex);
+      return next;
+    });
+  }, [selectedIndex]);
+
+  const pageFallback = (
+    <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: 200 }}>
+      <CircularProgress aria-label={t('app.loadingTheme')} />
+    </Box>
+  );
 
   const drawer = (
     <div>
@@ -115,6 +155,8 @@ const Layout = () => {
                   setMobileOpen(false);
                 }
               }}
+              onMouseEnter={() => preloadPage(item.preload)}
+              onFocus={() => preloadPage(item.preload)}
             >
               <ListItemIcon>
                 {item.icon}
@@ -126,8 +168,6 @@ const Layout = () => {
       </List>
     </div>
   );
-
-  const ActivePage = navItems[selectedIndex].Page;
 
   return (
     <Box sx={{ display: 'flex' }}>
@@ -192,19 +232,26 @@ const Layout = () => {
           width: { sm: `calc(100% - ${desktopOpen ? drawerWidth : 0}px)` },
           marginTop: '64px',
           height: 'calc(100vh - 64px)',
-          overflow: 'auto',
+          overflow: 'hidden',
           boxSizing: 'border-box'
         }}
       >
-        <Suspense
-          fallback={(
-            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: 200 }}>
-              <CircularProgress aria-label={t('app.loadingTheme')} />
+        {navItems.map((item, index) => (
+          visitedPages.has(index) ? (
+            <Box
+              key={item.text}
+              sx={{
+                display: selectedIndex === index ? 'block' : 'none',
+                height: '100%',
+                overflow: 'auto',
+              }}
+            >
+              <Suspense fallback={pageFallback}>
+                <item.Page />
+              </Suspense>
             </Box>
-          )}
-        >
-          <ActivePage />
-        </Suspense>
+          ) : null
+        ))}
       </Box>
     </Box>
   );

--- a/app/src/hooks/useBackgroundAwareTimeout.ts
+++ b/app/src/hooks/useBackgroundAwareTimeout.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useRef, type MutableRefObject } from 'react';
+
+type TimerEntry = {
+  expiresAtRef: MutableRefObject<number | null>;
+  onExpireRef: MutableRefObject<() => void>;
+  clearTimer: () => void;
+};
+
+const activeTimers = new Set<TimerEntry>();
+let globalListenersAttached = false;
+
+function dismissExpiredTimers() {
+  for (const entry of activeTimers) {
+    if (entry.expiresAtRef.current !== null && Date.now() >= entry.expiresAtRef.current) {
+      entry.clearTimer();
+      entry.onExpireRef.current();
+    }
+  }
+}
+
+function attachGlobalListeners() {
+  if (globalListenersAttached) {
+    return;
+  }
+
+  globalListenersAttached = true;
+  document.addEventListener('visibilitychange', dismissExpiredTimers);
+  window.addEventListener('focus', dismissExpiredTimers);
+}
+
+export function useBackgroundAwareTimeout(onExpire: () => void) {
+  const expiresAtRef = useRef<number | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onExpireRef = useRef(onExpire);
+  onExpireRef.current = onExpire;
+
+  const clearTimer = useCallback(() => {
+    expiresAtRef.current = null;
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  const startTimer = useCallback((duration: number) => {
+    clearTimer();
+    expiresAtRef.current = Date.now() + duration;
+    timeoutRef.current = setTimeout(() => {
+      clearTimer();
+      onExpireRef.current();
+    }, duration);
+  }, [clearTimer]);
+
+  useEffect(() => {
+    attachGlobalListeners();
+
+    const entry: TimerEntry = { expiresAtRef, onExpireRef, clearTimer };
+    activeTimers.add(entry);
+
+    return () => {
+      activeTimers.delete(entry);
+      clearTimer();
+    };
+  }, [clearTimer]);
+
+  return { startTimer, clearTimer };
+}

--- a/app/src/hooks/useConnectionSelection.ts
+++ b/app/src/hooks/useConnectionSelection.ts
@@ -5,29 +5,40 @@ export const useConnectionSelection = () => {
   const { connections } = useVMixStatus();
   const [selectedConnection, setSelectedConnection] = useState<string>('');
 
-  // Memoize connected connections to avoid recalculation
-  const connectedConnections = useMemo(() => 
-    connections.filter(conn => conn.status === 'Connected'), 
+  const connectedConnections = useMemo(
+    () => connections.filter(conn => conn.status === 'Connected'),
     [connections]
   );
 
-  // Simplified auto-selection logic with minimal useEffect
+  const effectiveSelectedConnection = useMemo(() => {
+    if (
+      selectedConnection &&
+      connectedConnections.some(conn => conn.host === selectedConnection)
+    ) {
+      return selectedConnection;
+    }
+    return connectedConnections[0]?.host ?? '';
+  }, [selectedConnection, connectedConnections]);
+
   useEffect(() => {
-    if (connectedConnections.length > 0 && !selectedConnection) {
-      setSelectedConnection(connectedConnections[0].host);
-    } else if (connectedConnections.length === 0) {
-      setSelectedConnection('');
-    } else if (selectedConnection && !connectedConnections.find(conn => conn.host === selectedConnection)) {
-      // If current selection is no longer connected, switch to first available
-      if (connectedConnections.length > 0) {
-        setSelectedConnection(connectedConnections[0].host);
+    if (connectedConnections.length === 0) {
+      if (selectedConnection !== '') {
+        setSelectedConnection('');
       }
+      return;
+    }
+
+    if (
+      selectedConnection &&
+      !connectedConnections.some(conn => conn.host === selectedConnection)
+    ) {
+      setSelectedConnection(connectedConnections[0].host);
     }
   }, [connectedConnections, selectedConnection]);
 
   return {
-    selectedConnection,
+    selectedConnection: effectiveSelectedConnection,
     setSelectedConnection,
-    connectedConnections
+    connectedConnections,
   };
 };

--- a/app/src/hooks/useToast.tsx
+++ b/app/src/hooks/useToast.tsx
@@ -1,0 +1,126 @@
+import { useCallback, useRef, useState } from 'react';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
+import type { SnackbarOrigin } from '@mui/material/Snackbar';
+import { useBackgroundAwareTimeout } from './useBackgroundAwareTimeout';
+
+export type ToastSeverity = 'success' | 'error' | 'info';
+
+export interface ToastState {
+  open: boolean;
+  message: string;
+  severity: ToastSeverity;
+  pulseId: number;
+}
+
+const DEFAULT_DURATION = 3000;
+const RETRIGGER_GAP_MS = 120;
+
+export function useToast(duration = DEFAULT_DURATION) {
+  const [toast, setToast] = useState<ToastState>({
+    open: false,
+    message: '',
+    severity: 'info',
+    pulseId: 0,
+  });
+
+  const toastOpenRef = useRef(false);
+  const pulseIdRef = useRef(0);
+  const reopenTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const hideToast = useCallback(() => {
+    toastOpenRef.current = false;
+    setToast(prev => ({ ...prev, open: false }));
+  }, []);
+
+  const { startTimer, clearTimer } = useBackgroundAwareTimeout(hideToast);
+
+  const showToast = useCallback(
+    (message: string, severity: ToastSeverity = 'success', customDuration?: number) => {
+      clearTimer();
+
+      if (reopenTimeoutRef.current) {
+        clearTimeout(reopenTimeoutRef.current);
+        reopenTimeoutRef.current = null;
+      }
+
+      const nextPulseId = ++pulseIdRef.current;
+      const timerDuration = customDuration ?? duration;
+      const nextToast: ToastState = {
+        open: true,
+        message,
+        severity,
+        pulseId: nextPulseId,
+      };
+
+      const openToast = () => {
+        toastOpenRef.current = true;
+        setToast(nextToast);
+        startTimer(timerDuration);
+      };
+
+      if (toastOpenRef.current) {
+        toastOpenRef.current = false;
+        setToast(prev => ({ ...prev, open: false }));
+        reopenTimeoutRef.current = setTimeout(() => {
+          reopenTimeoutRef.current = null;
+          openToast();
+        }, RETRIGGER_GAP_MS);
+        return;
+      }
+
+      openToast();
+    },
+    [duration, startTimer, clearTimer]
+  );
+
+  const handleCloseToast = useCallback(() => {
+    if (reopenTimeoutRef.current) {
+      clearTimeout(reopenTimeoutRef.current);
+      reopenTimeoutRef.current = null;
+    }
+    clearTimer();
+    hideToast();
+  }, [clearTimer, hideToast]);
+
+  return { toast, showToast, hideToast: handleCloseToast };
+}
+
+interface ToastSnackbarProps {
+  toast: ToastState;
+  onClose: () => void;
+  anchorOrigin?: SnackbarOrigin;
+  variant?: 'filled' | 'standard' | 'outlined';
+}
+
+export function ToastSnackbar({
+  toast,
+  onClose,
+  anchorOrigin = { vertical: 'bottom', horizontal: 'right' },
+  variant = 'filled',
+}: ToastSnackbarProps) {
+  return (
+    <Snackbar
+      key={toast.pulseId}
+      open={toast.open}
+      onClose={onClose}
+      anchorOrigin={anchorOrigin}
+    >
+      <Alert
+        severity={toast.severity}
+        sx={{
+          width: '100%',
+          animation: toast.open ? 'toastPulse 220ms ease-out' : 'none',
+          '@keyframes toastPulse': {
+            '0%': { transform: 'scale(0.96)', opacity: 0.7 },
+            '100%': { transform: 'scale(1)', opacity: 1 },
+          },
+        }}
+        variant={variant}
+        onClose={onClose}
+      >
+        {toast.message}
+      </Alert>
+    </Snackbar>
+  );
+}

--- a/app/src/hooks/useUISettings.tsx
+++ b/app/src/hooks/useUISettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, createContext, useContext } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, createContext, useContext } from 'react';
 import { settingsService } from '../services/settingsService';
 
 export type UIDensity = 'compact' | 'comfortable' | 'spacious';
@@ -15,9 +15,7 @@ export const UISettingsProvider = ({ children }: { children: React.ReactNode }) 
   const [uiDensity, setUiDensity] = useState<UIDensity>('comfortable');
   const [isLoading, setIsLoading] = useState(true);
 
-
-  // Load UI settings from backend
-  const loadUISettings = async () => {
+  const loadUISettings = useCallback(async () => {
     try {
       setIsLoading(true);
       const appSettings = await settingsService.getAppSettings();
@@ -26,22 +24,24 @@ export const UISettingsProvider = ({ children }: { children: React.ReactNode }) 
       }
     } catch (error) {
       console.error('Failed to load UI settings:', error);
-      // Use defaults
       setUiDensity('comfortable');
     } finally {
       setIsLoading(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
     loadUISettings();
-  }, []);
+  }, [loadUISettings]);
 
-  const contextValue: UISettingsContextType = {
-    uiDensity,
-    isLoading,
-    refreshSettings: loadUISettings,
-  };
+  const contextValue = useMemo<UISettingsContextType>(
+    () => ({
+      uiDensity,
+      isLoading,
+      refreshSettings: loadUISettings,
+    }),
+    [uiDensity, isLoading, loadUISettings]
+  );
 
   return <UISettingsContext.Provider value={contextValue}>{children}</UISettingsContext.Provider>;
 };

--- a/app/src/hooks/useVMixStatus.ts
+++ b/app/src/hooks/useVMixStatus.ts
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, createContext, useContext, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, createContext, useContext, useCallback, useMemo, useRef } from 'react';
 import { vmixService, type VmixConnection, type VmixInput, type VmixVideoListInput, type AutoRefreshConfig } from '../services/vmixService';
 
 // Types are now imported from vmixService
@@ -36,6 +36,8 @@ export const VMixStatusProvider = ({ children }: { children: React.ReactNode }) 
   
   // Track optimistically removed connections to ignore status updates temporarily
   const [optimisticallyRemovedHosts, setOptimisticallyRemovedHosts] = useState<Set<string>>(new Set());
+  const optimisticallyRemovedHostsRef = useRef(optimisticallyRemovedHosts);
+  optimisticallyRemovedHostsRef.current = optimisticallyRemovedHosts;
 
   const fetchInputsForHost = useCallback(async (host: string) => {
     try {
@@ -105,7 +107,7 @@ export const VMixStatusProvider = ({ children }: { children: React.ReactNode }) 
       const updatedConnection = event.payload;
       
       // Ignore status updates for optimistically removed hosts
-      if (optimisticallyRemovedHosts.has(updatedConnection.host)) {
+      if (optimisticallyRemovedHostsRef.current.has(updatedConnection.host)) {
         console.log(`Ignoring status update for optimistically removed host: ${updatedConnection.host}`);
         return;
       }
@@ -149,7 +151,7 @@ export const VMixStatusProvider = ({ children }: { children: React.ReactNode }) 
     return () => {
       unlistenStatus.then(f => f());
     };
-  }, [fetchInputsForHost, fetchVideoListsForHost, optimisticallyRemovedHosts]);
+  }, [fetchInputsForHost, fetchVideoListsForHost]);
 
   // Listen for connection removal events
   useEffect(() => {

--- a/app/src/locales/ja.json
+++ b/app/src/locales/ja.json
@@ -34,14 +34,14 @@
       "shortcutGenerator": "Shortcut Generator",
       "blankGenerator": "Blank作成",
       "inputManager": "Input管理",
-      "listManager": "リスト管理",
+      "listManager": "List管理",
       "settings": "設定",
       "about": "アプリについて"
     }
   },
   "app": {
     "loadingTheme": "テーマを読み込み中...",
-    "listManagerTitle": "リスト管理"
+    "listManagerTitle": "List管理"
   },
   "connectionSelector": {
     "defaultLabel": "vMix接続",
@@ -211,7 +211,7 @@
   },
   "listManager": {
     "noConnections": "vMix接続がありません。先に接続してください。",
-    "title": "リスト管理",
+    "title": "List管理",
     "connectionSettings": "接続設定",
     "noVideoLists": "選択した接続にVideoList Inputがありません。"
   },

--- a/app/src/pages/BlankGenerator.tsx
+++ b/app/src/pages/BlankGenerator.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 import { useVMixStatus } from '../hooks/useVMixStatus';
 import { useConnectionSelection } from '../hooks/useConnectionSelection';
 import ConnectionSelector from '../components/ConnectionSelector';
-import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Checkbox from '@mui/material/Checkbox';
@@ -15,7 +14,7 @@ import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Paper from '@mui/material/Paper';
-import Snackbar from '@mui/material/Snackbar';
+import { useToast, ToastSnackbar } from '../hooks/useToast';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 
@@ -28,9 +27,7 @@ const BlankGenerator = () => {
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
   const [generating, setGenerating] = useState(false);
 
-  const [toastOpen, setToastOpen] = useState(false);
-  const [toastMessage, setToastMessage] = useState('');
-  const [toastSeverity, setToastSeverity] = useState<'success' | 'error'>('success');
+  const { toast, showToast, hideToast } = useToast(6000);
 
   const { selectedConnection, setSelectedConnection, connectedConnections } = useConnectionSelection();
 
@@ -82,14 +79,10 @@ const BlankGenerator = () => {
       await getVMixInputs(selectedConnection);
 
       const bg = transparent ? t('common.transparent') : t('common.black');
-      setToastMessage(t('blank.success', { count, plural: count !== 1 ? 's' : '', bg }));
-      setToastSeverity('success');
-      setToastOpen(true);
+      showToast(t('blank.success', { count, plural: count !== 1 ? 's' : '', bg }), 'success');
     } catch (error) {
       console.error('Failed to generate blanks:', error);
-      setToastMessage(t('blank.fail', { error: String(error) }));
-      setToastSeverity('error');
-      setToastOpen(true);
+      showToast(t('blank.fail', { error: String(error) }), 'error');
     } finally {
       setGenerating(false);
     }
@@ -97,10 +90,6 @@ const BlankGenerator = () => {
 
   const handleCancelGenerate = () => {
     setShowConfirmDialog(false);
-  };
-
-  const handleToastClose = () => {
-    setToastOpen(false);
   };
 
   const bgWord = transparent ? t('common.transparent') : t('common.black');
@@ -197,20 +186,7 @@ const BlankGenerator = () => {
         </DialogActions>
       </Dialog>
 
-      <Snackbar
-        open={toastOpen}
-        autoHideDuration={6000}
-        onClose={handleToastClose}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-      >
-        <Alert
-          onClose={handleToastClose}
-          severity={toastSeverity}
-          sx={{ width: '100%' }}
-        >
-          {toastMessage}
-        </Alert>
-      </Snackbar>
+      <ToastSnackbar toast={toast} onClose={hideToast} variant="standard" />
     </Box>
   );
 };

--- a/app/src/pages/Connections.tsx
+++ b/app/src/pages/Connections.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useVMixStatus } from '../hooks/useVMixStatus';
 import { settingsService } from '../services/settingsService';
@@ -22,6 +22,7 @@ import IconButton from '@mui/material/IconButton';
 import MenuItem from '@mui/material/MenuItem';
 import Paper from '@mui/material/Paper';
 import Select from '@mui/material/Select';
+import { useBackgroundAwareTimeout } from '../hooks/useBackgroundAwareTimeout';
 import Snackbar from '@mui/material/Snackbar';
 import Switch from '@mui/material/Switch';
 import Table from '@mui/material/Table';
@@ -81,6 +82,21 @@ const Connections: React.FC = () => {
   const [backgroundConnections, setBackgroundConnections] = useState<Set<string>>(new Set());
   const [connectionNotifications, setConnectionNotifications] = useState<Array<{host: string, success: boolean, message: string}>>([]);
 
+  const dismissNextNotification = useCallback(() => {
+    setConnectionNotifications(prev => prev.slice(1));
+  }, []);
+
+  const { startTimer, clearTimer } = useBackgroundAwareTimeout(dismissNextNotification);
+
+  useEffect(() => {
+    if (connectionNotifications.length === 0) {
+      clearTimer();
+      return;
+    }
+
+    startTimer(5000);
+  }, [connectionNotifications, startTimer, clearTimer]);
+
   // Preset path display toggle
   const [showFullPresetPaths, setShowFullPresetPaths] = useState(false);
 
@@ -132,15 +148,6 @@ const Connections: React.FC = () => {
 
     return () => clearTimeout(timeout);
   }, [isInitialLoading]);
-
-  // Clear old notifications
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setConnectionNotifications(prev => prev.slice(1));
-    }, 5000);
-
-    return () => clearTimeout(timer);
-  }, [connectionNotifications]);
 
   const handleClickOpen = () => {
     setOpen(true);
@@ -1158,8 +1165,7 @@ const Connections: React.FC = () => {
       {connectionNotifications.length > 0 ? (
         <Snackbar
           open={true}
-          autoHideDuration={5000}
-          onClose={() => setConnectionNotifications(prev => prev.slice(1))}
+          onClose={dismissNextNotification}
           anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
         >
           <Alert

--- a/app/src/pages/Developer.tsx
+++ b/app/src/pages/Developer.tsx
@@ -14,13 +14,11 @@ import ListItemText from '@mui/material/ListItemText';
 import Paper from '@mui/material/Paper';
 import SvgIcon, { type SvgIconProps } from '@mui/material/SvgIcon';
 import Typography from '@mui/material/Typography';
-import {
-  GitHub,
-  Code,
-  FavoriteOutlined,
-  Description,
-  Public,
-} from '@mui/icons-material';
+import CodeIcon from '@mui/icons-material/Code';
+import DescriptionIcon from '@mui/icons-material/Description';
+import FavoriteOutlinedIcon from '@mui/icons-material/FavoriteOutlined';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import PublicIcon from '@mui/icons-material/Public';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { useTranslation, Trans } from 'react-i18next';
 import { useTheme } from '../hooks/useTheme';
@@ -59,7 +57,7 @@ const Developer = () => {
             <CardContent>
               <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
                 <Avatar sx={{ mr: 2, bgcolor: 'primary.main' }}>
-                  <GitHub />
+                  <GitHubIcon />
                 </Avatar>
                 <Box>
                   <Typography variant="h6" component="h2">
@@ -85,7 +83,7 @@ const Developer = () => {
 
               <Button
                 variant="contained"
-                startIcon={<GitHub />}
+                startIcon={<GitHubIcon />}
                 onClick={() => openInBrowser(repositoryUrl)}
                 fullWidth
               >
@@ -100,7 +98,7 @@ const Developer = () => {
             <CardContent>
               <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
                 <Avatar sx={{ mr: 2, bgcolor: 'primary.main' }}>
-                  <Code />
+                  <CodeIcon />
                 </Avatar>
                 <Box>
                   <Typography variant="h6" component="h2">
@@ -119,7 +117,7 @@ const Developer = () => {
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1, mt: 2 }}>
                 <Button
                   variant="contained"
-                  startIcon={<Public />}
+                  startIcon={<PublicIcon />}
                   onClick={() => openInBrowser(mikanseiLaboratoryUrl)}
                   fullWidth
                 >
@@ -127,7 +125,7 @@ const Developer = () => {
                 </Button>
                 <Button
                   variant="outlined"
-                  startIcon={<GitHub />}
+                  startIcon={<GitHubIcon />}
                   onClick={() => openInBrowser(developerGitHub)}
                   fullWidth
                 >
@@ -142,7 +140,7 @@ const Developer = () => {
           <Card elevation={3}>
             <CardContent>
               <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
-                <FavoriteOutlined sx={{ mr: 1, color: 'error.main' }} />
+                <FavoriteOutlinedIcon sx={{ mr: 1, color: 'error.main' }} />
                 <Typography variant="h6" component="h2">
                   {t('developer.supportTitle')}
                 </Typography>
@@ -192,7 +190,7 @@ const Developer = () => {
         <Grid2 size={12}>
           <Paper sx={{ p: 3 }}>
             <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
-              <Description sx={{ mr: 1 }} />
+              <DescriptionIcon sx={{ mr: 1 }} />
               <Typography variant="h6" component="h2">
                 {t('developer.licenseTitle')}
               </Typography>
@@ -258,7 +256,7 @@ SOFTWARE.`}
               <ListItem sx={{ pl: 0 }}>
                 <ListItemIcon>
                   <Avatar sx={{ bgcolor: 'primary.main' }}>
-                    <Code />
+                    <CodeIcon />
                   </Avatar>
                 </ListItemIcon>
                 <ListItemText
@@ -277,7 +275,7 @@ SOFTWARE.`}
               <ListItem sx={{ pl: 0 }}>
                 <ListItemIcon>
                   <Avatar sx={{ bgcolor: 'primary.main' }}>
-                    <Code />
+                    <CodeIcon />
                   </Avatar>
                 </ListItemIcon>
                 <ListItemText
@@ -306,7 +304,7 @@ SOFTWARE.`}
             <List>
               <ListItem sx={{ pl: 0 }}>
                 <ListItemIcon>
-                  <GitHub />
+                  <GitHubIcon />
                 </ListItemIcon>
                 <ListItemText
                   primary={
@@ -342,7 +340,7 @@ SOFTWARE.`}
 
               <ListItem sx={{ pl: 0 }}>
                 <ListItemIcon>
-                  <Description />
+                  <DescriptionIcon />
                 </ListItemIcon>
                 <ListItemText
                   primary={
@@ -360,7 +358,7 @@ SOFTWARE.`}
 
               <ListItem sx={{ pl: 0 }}>
                 <ListItemIcon>
-                  <Code />
+                  <CodeIcon />
                 </ListItemIcon>
                 <ListItemText
                   primary={

--- a/app/src/pages/InputManager.tsx
+++ b/app/src/pages/InputManager.tsx
@@ -15,7 +15,7 @@ import DialogTitle from '@mui/material/DialogTitle';
 import IconButton from '@mui/material/IconButton';
 import Paper from '@mui/material/Paper';
 import Skeleton from '@mui/material/Skeleton';
-import Snackbar from '@mui/material/Snackbar';
+import { useToast, ToastSnackbar } from '../hooks/useToast';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
@@ -53,12 +53,6 @@ interface InputRowProps {
   onDeleteClick: (key: string) => void;
   onTitleChange: (key: string, value: string) => void;
   onCopyKey: (key: string) => void;
-}
-
-interface ToastState {
-  open: boolean;
-  message: string;
-  severity: 'success' | 'error' | 'info';
 }
 
 
@@ -205,11 +199,11 @@ const InputRow = OptimizedInputRow;
 
 const InputManager = () => {
   const { t } = useTranslation();
-  const { connections, inputs: globalInputs, sendVMixFunction, getVMixInputs } = useVMixStatus();
+  const { connections, inputs: globalInputs, inputsLoading, sendVMixFunction, getVMixInputs } = useVMixStatus();
   const { uiDensity } = useUISettings();
   const spacing = getDensitySpacing(uiDensity);
   const [error, setError] = useState<string | null>(null);
-  const [toast, setToast] = useState<ToastState>({ open: false, message: '', severity: 'info' });
+  const { toast, showToast, hideToast } = useToast();
   
   // Single editing state to minimize re-renders
   const [editingData, setEditingData] = useState<{[key: string]: string}>({});
@@ -240,8 +234,12 @@ const InputManager = () => {
     return [];
   }, [selectedConnection, globalInputs]);
 
-  // Show loading only when we have a selected connection but no data yet
-  const isLoading = selectedConnection && !globalInputs[selectedConnection];
+  // Show skeleton only while inputs are actively being fetched
+  const isLoading = Boolean(
+    selectedConnection &&
+    !globalInputs[selectedConnection] &&
+    inputsLoading[selectedConnection] !== false
+  );
 
 
   const handleEditClick = useCallback((input: Input) => {
@@ -265,7 +263,7 @@ const InputManager = () => {
         // Refresh inputs to get latest XML data
         await getVMixInputs(selectedConnection);
 
-        setToast({ open: true, message: t('inputManager.toastTitleUpdated'), severity: 'success' });
+        showToast(t('inputManager.toastTitleUpdated'), 'success');
         
         // Remove from editing data
         setEditingData(currentEditingData => {
@@ -274,7 +272,7 @@ const InputManager = () => {
         });
       } catch (error) {
         console.error('Failed to update input title:', error);
-        setToast({ open: true, message: t('inputManager.toastTitleFailed'), severity: 'error' });
+        showToast(t('inputManager.toastTitleFailed'), 'error');
       } finally {
         setOperationLoading(prev => {
           const { [key]: _, ...rest } = prev;
@@ -315,11 +313,11 @@ const InputManager = () => {
         // Refresh inputs to get latest XML data
         await getVMixInputs(selectedConnection);
 
-        setToast({ open: true, message: t('inputManager.toastDeleted'), severity: 'success' });
+        showToast(t('inputManager.toastDeleted'), 'success');
       } catch (error) {
         console.error('Failed to delete input:', error);
         setError(t('inputManager.deleteFailedDetail', { error: String(error) }));
-        setToast({ open: true, message: t('inputManager.toastDeleteFailed'), severity: 'error' });
+        showToast(t('inputManager.toastDeleteFailed'), 'error');
       } finally {
         setOperationLoading(prev => {
           const { [`delete_${inputToDelete.key}`]: _, ...rest } = prev;
@@ -338,7 +336,7 @@ const InputManager = () => {
 
   const handleCopyKey = useCallback((key: string) => {
     navigator.clipboard.writeText(key);
-    setToast({ open: true, message: t('inputManager.toastKeyCopied'), severity: 'success' });
+    showToast(t('inputManager.toastKeyCopied'), 'success');
   }, [t]);
 
   const handleRequestSort = (property: OrderBy) => {
@@ -509,21 +507,7 @@ const InputManager = () => {
         </TableContainer>
       )}
       
-      {/* Toast Notification */}
-      <Snackbar 
-        open={toast.open} 
-        autoHideDuration={3000} 
-        onClose={() => setToast(prev => ({ ...prev, open: false }))}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-      >
-        <Alert 
-          severity={toast.severity} 
-          sx={{ width: '100%' }}
-          variant="filled"
-        >
-          {toast.message}
-        </Alert>
-      </Snackbar>
+      <ToastSnackbar toast={toast} onClose={hideToast} />
       {connections.length > 0 ? (
         <Box sx={{ mt: 2, display: 'flex', justifyContent: 'flex-end' }}>
           <Button

--- a/app/src/pages/ListManager.tsx
+++ b/app/src/pages/ListManager.tsx
@@ -33,7 +33,7 @@ interface VmixVideoListInput {
 
 const ListManager: React.FC = () => {
   const { t } = useTranslation();
-  const { videoLists: contextVideoLists, getVMixVideoLists, selectVideoListItem, openVideoListWindow } = useVMixStatus();
+  const { videoLists: contextVideoLists, videoListsLoading, getVMixVideoLists, selectVideoListItem, openVideoListWindow } = useVMixStatus();
   const [_error, _setError] = useState<string | null>(null);
   const [expandedLists] = useState<Set<string>>(new Set());
 
@@ -49,7 +49,11 @@ const ListManager: React.FC = () => {
     [selectedHost, contextVideoLists]
   );
 
-  const isLoading = connectedConnections.length === 0 || (selectedHost && !contextVideoLists[selectedHost]);
+  const isLoading = Boolean(
+    selectedHost &&
+    !contextVideoLists[selectedHost] &&
+    videoListsLoading[selectedHost] !== false
+  );
 
   useEffect(() => {
     if (selectedHost && !contextVideoLists[selectedHost]) {

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -8,7 +8,6 @@ import { invoke } from '@tauri-apps/api/core';
 import { applySavedLocale } from '../i18n/config';
 import type { SettingsLocaleChoice } from '../i18n/locale';
 import { parseStoredLocaleForSettings } from '../i18n/locale';
-import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
@@ -22,7 +21,7 @@ import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import Paper from '@mui/material/Paper';
 import Select from '@mui/material/Select';
-import Snackbar from '@mui/material/Snackbar';
+import { useToast, ToastSnackbar } from '../hooks/useToast';
 import Switch from '@mui/material/Switch';
 import Typography from '@mui/material/Typography';
 import FolderOpenIcon from '@mui/icons-material/FolderOpen';
@@ -58,29 +57,13 @@ const Settings = () => {
 
   const [checkingUpdate, setCheckingUpdate] = useState(false);
 
-  const [toast, setToast] = useState<{
-    open: boolean;
-    message: string;
-    severity: 'success' | 'error' | 'info';
-  }>({
-    open: false,
-    message: '',
-    severity: 'info',
-  });
+  const { toast, showToast, hideToast } = useToast(6000);
 
   const handleChange = (name: string, value: unknown) => {
     setSettings({
       ...settings,
       [name]: value
     });
-  };
-
-  const showToast = (message: string, severity: 'success' | 'error' | 'info' = 'info') => {
-    setToast({ open: true, message, severity });
-  };
-
-  const handleCloseToast = () => {
-    setToast(prev => ({ ...prev, open: false }));
   };
 
   const handleOpenLogsDirectory = async () => {
@@ -457,21 +440,7 @@ const Settings = () => {
         )}
       </Paper>
 
-      <Snackbar
-        open={toast.open}
-        autoHideDuration={6000}
-        onClose={handleCloseToast}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-      >
-        <Alert
-          severity={toast.severity}
-          sx={{ width: '100%' }}
-          variant="filled"
-          onClose={handleCloseToast}
-        >
-          {toast.message}
-        </Alert>
-      </Snackbar>
+      <ToastSnackbar toast={toast} onClose={hideToast} />
     </Box>
   );
 };

--- a/app/src/pages/ShortcutGenerator.tsx
+++ b/app/src/pages/ShortcutGenerator.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, memo, useRef, useEffect, useTransition, type ComponentType } from 'react';
+import { useState, useMemo, useCallback, memo, useRef, useEffect, useTransition, forwardRef, useImperativeHandle, type ComponentType } from 'react';
 import type { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { openUrl } from '@tauri-apps/plugin-opener';
@@ -85,6 +85,139 @@ type VirtualizedInputItemData = {
 const VirtualizedInputList = FixedSizeList as unknown as ComponentType<
   FixedSizeListProps<VirtualizedInputItemData>
 >;
+
+const FUNCTION_NAME_COMMIT_MS = 400;
+const MAX_SHORTCUT_SUGGESTIONS = 50;
+
+interface FunctionNameFieldHandle {
+  commitAndGet: () => string;
+}
+
+interface FunctionNameFieldProps {
+  value: string;
+  onChange: (name: string) => void;
+  shortcutsData: ShortcutData[];
+  label: string;
+  paramsLabel: string;
+}
+
+const FunctionNameField = memo(forwardRef<FunctionNameFieldHandle, FunctionNameFieldProps>(
+  function FunctionNameField({ value, onChange, shortcutsData, label, paramsLabel }, ref) {
+    const [draft, setDraft] = useState(value);
+    const draftRef = useRef(draft);
+    draftRef.current = draft;
+    const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    useEffect(() => {
+      setDraft(value);
+    }, [value]);
+
+    const commit = useCallback((name: string) => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
+      onChange(name);
+    }, [onChange]);
+
+    const scheduleCommit = useCallback((name: string) => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+      debounceRef.current = setTimeout(() => {
+        debounceRef.current = null;
+        onChange(name);
+      }, FUNCTION_NAME_COMMIT_MS);
+    }, [onChange]);
+
+    useEffect(() => () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    }, []);
+
+    useImperativeHandle(ref, () => ({
+      commitAndGet: () => {
+        const name = draftRef.current;
+        commit(name);
+        return name;
+      },
+    }), [commit]);
+
+    const filterOptions = useCallback((options: ShortcutData[], state: { inputValue: string }) => {
+      const term = state.inputValue.trim().toLowerCase();
+      if (!term) {
+        return [];
+      }
+
+      const results: ShortcutData[] = [];
+      for (const shortcut of options) {
+        if (shortcut.Name.toLowerCase().includes(term)) {
+          results.push(shortcut);
+          if (results.length >= MAX_SHORTCUT_SUGGESTIONS) {
+            break;
+          }
+        }
+      }
+      return results;
+    }, []);
+
+    return (
+      <Autocomplete
+        freeSolo
+        options={shortcutsData}
+        getOptionLabel={(option) => (typeof option === 'string' ? option : option.Name)}
+        inputValue={draft}
+        onInputChange={(_event, newInputValue, reason) => {
+          if (reason !== 'input' && reason !== 'clear') {
+            return;
+          }
+          setDraft(newInputValue);
+          scheduleCommit(newInputValue);
+        }}
+        onChange={(_event, newValue) => {
+          if (newValue && typeof newValue !== 'string') {
+            setDraft(newValue.Name);
+            commit(newValue.Name);
+          }
+        }}
+        filterOptions={filterOptions}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            label={label}
+            size="small"
+            sx={{ width: '220px', flexShrink: 0 }}
+            onBlur={() => {
+              if (draftRef.current !== value) {
+                commit(draftRef.current);
+              }
+            }}
+          />
+        )}
+        renderOption={(props, option) => (
+          <Box component="li" {...props}>
+            <Box>
+              <Typography variant="body2" fontWeight="bold">
+                {option.Name}
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                {option.Description}
+              </Typography>
+              {option.Parameters ? (
+                <Typography variant="caption" color="text.secondary" display="block">
+                  {paramsLabel} {option.Parameters.join(', ')}
+                </Typography>
+              ) : null}
+            </Box>
+          </Box>
+        )}
+      />
+    );
+  }
+));
+
+FunctionNameField.displayName = 'FunctionNameField';
 
 // Virtualized row component for react-window
 const VirtualizedInputItem = memo((props: ListChildComponentProps<VirtualizedInputItemData>) => {
@@ -354,13 +487,7 @@ const ShortcutGenerator = () => {
   // Process shortcuts data
   const shortcutsData: ShortcutData[] = Array.isArray(shortcuts) ? shortcuts : [];
   
-  // Filter shortcuts based on search term
-  const getFilteredShortcuts = (searchTerm: string) => {
-    if (!searchTerm) return [];
-    return shortcutsData.filter(shortcut => 
-      shortcut.Name.toLowerCase().includes(searchTerm.toLowerCase())
-    );
-  };
+  const functionNameFieldRef = useRef<FunctionNameFieldHandle>(null);
   const { inputs: vmixStatusInputs, connections } = useVMixStatus();
   
   // Use optimized connection selection hook
@@ -561,12 +688,13 @@ const ShortcutGenerator = () => {
 
   // Apply queries from scraper data
   const handleApplyQueries = useCallback(() => {
-    if (!sharedFunctionName) {
+    const activeFunctionName = functionNameFieldRef.current?.commitAndGet() ?? sharedFunctionName;
+    if (!activeFunctionName) {
       showToast(t('shortcut.selectFunctionFirst'), 'error');
       return;
     }
 
-    const selectedShortcut = shortcutsData.find(s => s.Name === sharedFunctionName);
+    const selectedShortcut = shortcutsData.find(s => s.Name === activeFunctionName);
     if (!selectedShortcut) {
       showToast(t('shortcut.functionNotInScraper'), 'error');
       return;
@@ -795,51 +923,13 @@ const ShortcutGenerator = () => {
             <Collapse in={functionConfigExpanded}>
             {/* Function Name with Apply queries button */}
             <Box sx={{ mb: spacing.spacing, display: 'flex', alignItems: 'center', gap: spacing.spacing, flexWrap: 'wrap' }}>
-              <Autocomplete
-                freeSolo
-                options={shortcutsData}
-                getOptionLabel={(option) => {
-                  if (typeof option === 'string') return option;
-                  return option.Name;
-                }}
-                inputValue={sharedFunctionName}
-                onInputChange={(_event, newInputValue) => {
-                  startTransition(() => setSharedFunctionName(newInputValue));
-                }}
-                onChange={(_event, newValue) => {
-                  if (newValue && typeof newValue !== 'string') {
-                    startTransition(() => setSharedFunctionName(newValue.Name));
-                  }
-                }}
-                renderInput={(params) => (
-                  <TextField
-                    {...params}
-                    label={t('shortcut.functionName')}
-                    size="small"
-                    sx={{ width: '220px', flexShrink: 0 }}
-                  />
-                )}
-                renderOption={(props, option) => (
-                  <Box component="li" {...props}>
-                    <Box>
-                      <Typography variant="body2" fontWeight="bold">
-                        {option.Name}
-                      </Typography>
-                      <Typography variant="caption" color="text.secondary">
-                        {option.Description}
-                      </Typography>
-                      {option.Parameters ? (
-                        <Typography variant="caption" color="text.secondary" display="block">
-                          {t('shortcut.paramsLabel')} {option.Parameters.join(', ')}
-                        </Typography>
-                      ) : null}
-                    </Box>
-                  </Box>
-                )}
-                filterOptions={(_options, { inputValue }) => {
-                  const filtered = getFilteredShortcuts(inputValue);
-                  return filtered
-                }}
+              <FunctionNameField
+                ref={functionNameFieldRef}
+                value={sharedFunctionName}
+                onChange={setSharedFunctionName}
+                shortcutsData={shortcutsData}
+                label={t('shortcut.functionName')}
+                paramsLabel={t('shortcut.paramsLabel')}
               />
               
               <Button
@@ -868,9 +958,7 @@ const ShortcutGenerator = () => {
                     key={funcName}
                     label={funcName}
                     size="small"
-                    onClick={() => {
-                      startTransition(() => setSharedFunctionName(funcName));
-                    }}
+                    onClick={() => setSharedFunctionName(funcName)}
                     color={sharedFunctionName === funcName ? 'primary' : 'default'}
                     variant={sharedFunctionName === funcName ? 'filled' : 'outlined'}
                     sx={{ flexShrink: 0 }}

--- a/app/src/pages/ShortcutGenerator.tsx
+++ b/app/src/pages/ShortcutGenerator.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, memo, useRef, useEffect, type ComponentType } from 'react';
+import { useState, useMemo, useCallback, memo, useRef, useEffect, useTransition, type ComponentType } from 'react';
 import type { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { openUrl } from '@tauri-apps/plugin-opener';
@@ -21,7 +21,7 @@ import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import Paper from '@mui/material/Paper';
 import Select from '@mui/material/Select';
-import Snackbar from '@mui/material/Snackbar';
+import { useToast, ToastSnackbar } from '../hooks/useToast';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
@@ -71,7 +71,7 @@ interface ShortcutData {
 
 type VirtualizedInputItemData = {
   filteredInputs: Input[];
-  vmixInputs: VmixInput[];
+  vmixInputsByNumber: Map<number, VmixInput>;
   selectedConnection: string;
   showToast: (message: string, severity?: 'success' | 'error' | 'info') => void;
   onTryCommand: (input: Input) => void | Promise<void>;
@@ -89,9 +89,9 @@ const VirtualizedInputList = FixedSizeList as unknown as ComponentType<
 // Virtualized row component for react-window
 const VirtualizedInputItem = memo((props: ListChildComponentProps<VirtualizedInputItemData>) => {
   const { index, style, data } = props;
-  const { filteredInputs, vmixInputs, selectedConnection, showToast, onTryCommand, lastClickedInputId, onInputClick, t } = data;
+  const { filteredInputs, vmixInputsByNumber, selectedConnection, showToast, onTryCommand, lastClickedInputId, onInputClick, spacing, t } = data;
   const input = filteredInputs[index];
-  const vmixInput = vmixInputs.find(vi => vi.number === input.number);
+  const vmixInput = vmixInputsByNumber.get(input.number);
   const isLastItem = index === filteredInputs.length - 1;
   const isSpecialInput = input.id < 0;
   const isHighlighted = lastClickedInputId === input.id;
@@ -171,12 +171,14 @@ const VirtualizedInputItem = memo((props: ListChildComponentProps<VirtualizedInp
     <div style={style as React.CSSProperties}>
       <Box 
         sx={{ 
-          p: 1, 
+          px: spacing.listItemPadding,
+          py: spacing.listItemPadding * 0.5,
           display: 'flex', 
           alignItems: 'center', 
-          gap: 1,
-          flexWrap: 'wrap',
-          minHeight: '50px',
+          gap: spacing.spacing,
+          flexWrap: 'nowrap',
+          minHeight: spacing.itemHeight,
+          boxSizing: 'border-box',
           bgcolor: isHighlighted ? 'action.selected' : 'transparent',
           cursor: 'pointer',
           transition: 'background-color 0.2s ease'
@@ -185,9 +187,10 @@ const VirtualizedInputItem = memo((props: ListChildComponentProps<VirtualizedInp
       >
         {/* Input Info */}
         <Box sx={{ 
-          minWidth: '160px', 
-          maxWidth: '220px', 
-          overflow: 'hidden'
+          minWidth: '140px', 
+          maxWidth: '200px', 
+          overflow: 'hidden',
+          flexShrink: 0,
         }}>
           <Typography 
             variant="body2" 
@@ -196,7 +199,8 @@ const VirtualizedInputItem = memo((props: ListChildComponentProps<VirtualizedInp
               overflow: 'hidden',
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',
-              fontSize: '0.875rem'
+              fontSize: spacing.fontSize,
+              lineHeight: spacing.lineHeight,
             }}
             title={isSpecialInput ? input.title.replace(`${input.functionName} to `, '') : t('shortcut.inputLine', { num: input.number, name: vmixInput?.short_title || vmixInput?.title || t('shortcut.unknownInput') })}
           >
@@ -210,7 +214,8 @@ const VirtualizedInputItem = memo((props: ListChildComponentProps<VirtualizedInp
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',
               display: 'block',
-              fontSize: '0.7rem'
+              fontSize: `calc(${spacing.fontSize} - 0.05rem)`,
+              lineHeight: spacing.lineHeight,
             }}
             title={`${input.functionName} | ${input.queryParams.map(p => `${p.key}=${p.value}`).join(', ')}`}
           >
@@ -223,35 +228,24 @@ const VirtualizedInputItem = memo((props: ListChildComponentProps<VirtualizedInp
           flex: 1, 
           minWidth: 0,
           display: 'flex',
-          gap: 1,
+          gap: spacing.spacing,
           alignItems: 'center'
         }}>
           {/* Generated URL */}
           <Box sx={{ 
             flex: 1, 
             minWidth: 0,
-            minHeight: '36px'
+            height: '100%',
           }}>
             <Box sx={{ display: 'flex', alignItems: 'center', bgcolor: 'action.hover', borderRadius: 1, height: '100%' }}>
               <Box 
                 sx={{ 
                   flex: 1, 
-                  p: 0.75,
-                  overflow: 'auto',
-                  maxHeight: '60px',
-                  '&::-webkit-scrollbar': {
-                    height: '4px',
-                  },
-                  '&::-webkit-scrollbar-track': {
-                    background: 'transparent',
-                  },
-                  '&::-webkit-scrollbar-thumb': {
-                    background: 'rgba(0,0,0,0.2)',
-                    borderRadius: '2px',
-                  },
-                  '&::-webkit-scrollbar-thumb:hover': {
-                    background: 'rgba(0,0,0,0.3)',
-                  }
+                  px: spacing.listItemPadding,
+                  py: 0,
+                  overflow: 'hidden',
+                  display: 'flex',
+                  alignItems: 'center',
                 }}
               >
                 <Typography 
@@ -259,46 +253,66 @@ const VirtualizedInputItem = memo((props: ListChildComponentProps<VirtualizedInp
                   variant="caption" 
                   sx={{ 
                     fontFamily: 'monospace', 
-                    fontSize: '0.7rem',
+                    fontSize: `calc(${spacing.fontSize} - 0.05rem)`,
                     whiteSpace: 'nowrap',
                     margin: 0,
-                    lineHeight: 1.2
+                    lineHeight: spacing.lineHeight,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
                   }}
                 >
                   {generateUrl(input)}
                 </Typography>
               </Box>
               <IconButton
-                size="small"
+                size={spacing.iconSize}
                 onClick={(e) => handleCopyUrl(e)}
-                sx={{ p: 0.5, flexShrink: 0 }}
+                aria-label={t('shortcut.copyUrl')}
+                sx={{
+                  p: spacing.listItemPadding,
+                  flexShrink: 0,
+                  minWidth: spacing.itemHeight,
+                  minHeight: spacing.itemHeight,
+                }}
               >
-                <ContentCopyIcon fontSize="small" />
+                <ContentCopyIcon fontSize={spacing.iconSize} />
               </IconButton>
             </Box>
           </Box>
           
           {/* Action Buttons */}
-          <Box sx={{ flexShrink: 0 }}>
+          <Box sx={{ flexShrink: 0, ml: spacing.spacing }}>
             <ButtonGroup 
               variant="outlined" 
               size="small"
               sx={{ 
                 '& .MuiButton-root': { 
                   minWidth: 'auto', 
-                  px: 1
-                }
+                  px: 0.75,
+                  py: 0.25,
+                  minHeight: 26,
+                  fontSize: '0.6875rem',
+                  lineHeight: 1.2,
+                  textTransform: 'none',
+                  '& .MuiButton-startIcon': {
+                    marginRight: 0.375,
+                    marginLeft: -0.125,
+                    '& > *:nth-of-type(1)': {
+                      fontSize: '0.875rem',
+                    },
+                  },
+                },
               }}
             >
               <Button
-                startIcon={<CodeIcon fontSize="small" />}
+                startIcon={<CodeIcon />}
                 onClick={(e) => handleCopyScript(e)}
                 size="small"
               >
                 {t('shortcut.script')}
               </Button>
               <Button
-                startIcon={<OpenInBrowserIcon fontSize="small" />}
+                startIcon={<OpenInBrowserIcon />}
                 onClick={(e) => openTallyInBrowser(e, input)}
                 size="small"
                 disabled={isSpecialInput}
@@ -306,7 +320,7 @@ const VirtualizedInputItem = memo((props: ListChildComponentProps<VirtualizedInp
                 {t('shortcut.tally')}
               </Button>
               <Button
-                startIcon={<ContentCopyIcon fontSize="small" />}
+                startIcon={<ContentCopyIcon />}
                 onClick={(e) => handleCopyKey(e)}
                 size="small"
                 disabled={isSpecialInput}
@@ -314,7 +328,7 @@ const VirtualizedInputItem = memo((props: ListChildComponentProps<VirtualizedInp
                 {t('shortcut.keyBtn')}
               </Button>
               <Button
-                startIcon={<PlayArrowIcon fontSize="small" />}
+                startIcon={<PlayArrowIcon />}
                 color="primary"
                 onClick={(e) => handleTryCommand(e)}
                 size="small"
@@ -357,6 +371,16 @@ const ShortcutGenerator = () => {
   const vmixInputs = useMemo(() => {
     return selectedConnection ? (vmixStatusInputs[selectedConnection] || []) : [];
   }, [selectedConnection, vmixStatusInputs]);
+
+  const vmixInputsByNumber = useMemo(() => {
+    const map = new Map<number, VmixInput>();
+    for (const input of vmixInputs) {
+      map.set(input.number, input);
+    }
+    return map;
+  }, [vmixInputs]);
+
+  const [, startTransition] = useTransition();
 
   // Get suggestions for parameter value based on parameter key
   const getParameterValueSuggestions = useCallback((paramKey: string): Array<{ value: string; label: string }> => {
@@ -421,9 +445,7 @@ const ShortcutGenerator = () => {
     const key = paramKey.toLowerCase();
     return key === 'mix' || key === 'duration' || key.includes('volume') || key.includes('gain');
   }, []);
-  const [toast, setToast] = useState<{open: boolean, message: string, severity: 'success' | 'error' | 'info'}>(
-    {open: false, message: '', severity: 'info'}
-  );
+  const { toast, showToast, hideToast } = useToast();
   const [inputTypeFilter, setInputTypeFilter] = useState<string>('All');
   
   // Collapse states
@@ -509,35 +531,33 @@ const ShortcutGenerator = () => {
 
   const handleAddSharedParam = useCallback(() => {
     if (newParamKey && newParamValue) {
-      const newId = sharedQueryParams.length > 0
-        ? Math.max(...sharedQueryParams.map(p => p.id)) + 1
-        : 1;
-      
-      setSharedQueryParams([
-        ...sharedQueryParams,
-        { id: newId, key: newParamKey, value: newParamValue }
-      ]);
-      
+      startTransition(() => {
+        setSharedQueryParams(prev => {
+          const newId = prev.length > 0 ? Math.max(...prev.map(p => p.id)) + 1 : 1;
+          return [...prev, { id: newId, key: newParamKey, value: newParamValue }];
+        });
+      });
+
       setNewParamKey('');
       setNewParamValue('');
     }
-  }, [newParamKey, newParamValue, sharedQueryParams]);
+  }, [newParamKey, newParamValue, startTransition]);
 
   const handleDeleteSharedParam = useCallback((paramId: number) => {
-    setSharedQueryParams(prev => prev.filter(param => param.id !== paramId));
-  }, []);
+    startTransition(() => {
+      setSharedQueryParams(prev => prev.filter(param => param.id !== paramId));
+    });
+  }, [startTransition]);
 
   const handleSharedParamChange = useCallback((paramId: number, key: string, value: string) => {
-    setSharedQueryParams(prev => prev.map(param => 
-      param.id === paramId 
-        ? { ...param, key, value }
-        : param
-    ));
-  }, []);
-
-  const showToast = (message: string, severity: 'success' | 'error' | 'info' = 'success') => {
-    setToast({open: true, message, severity});
-  };
+    startTransition(() => {
+      setSharedQueryParams(prev => prev.map(param =>
+        param.id === paramId
+          ? { ...param, key, value }
+          : param
+      ));
+    });
+  }, [startTransition]);
 
   // Apply queries from scraper data
   const handleApplyQueries = useCallback(() => {
@@ -567,6 +587,10 @@ const ShortcutGenerator = () => {
       : 1;
 
     selectedShortcut.Parameters.forEach(paramKey => {
+      // Input is auto-added per input row; skip when applying scraper params
+      if (paramKey.toLowerCase() === 'input') {
+        return;
+      }
       if (!existingKeys.has(paramKey)) {
         newParams.push({
           id: nextId++,
@@ -581,13 +605,11 @@ const ShortcutGenerator = () => {
       return;
     }
 
-    setSharedQueryParams(prev => [...prev, ...newParams]);
+    startTransition(() => {
+      setSharedQueryParams(prev => [...prev, ...newParams]);
+    });
     showToast(t('shortcut.addedParams', { count: newParams.length }), 'success');
-  }, [sharedFunctionName, shortcutsData, sharedQueryParams, t]);
-
-  const handleCloseToast = () => {
-    setToast(prev => ({...prev, open: false}));
-  };
+  }, [sharedFunctionName, shortcutsData, sharedQueryParams, t, startTransition, showToast]);
 
   // Get unique input types from vmixInputs - memoized for performance
   const availableInputTypes = useMemo(() => {
@@ -610,10 +632,21 @@ const ShortcutGenerator = () => {
       return regularInputs;
     }
     return regularInputs.filter(input => {
-      const vmixInput = vmixInputs.find(vi => vi.number === input.number);
+      const vmixInput = vmixInputsByNumber.get(input.number);
       return vmixInput?.input_type === effectiveInputTypeFilter;
     });
-  }, [regularInputs, effectiveInputTypeFilter, vmixInputs]);
+  }, [regularInputs, effectiveInputTypeFilter, vmixInputsByNumber]);
+
+  const inputTypeCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const input of regularInputs) {
+      const type = vmixInputsByNumber.get(input.number)?.input_type;
+      if (type) {
+        counts.set(type, (counts.get(type) ?? 0) + 1);
+      }
+    }
+    return counts;
+  }, [regularInputs, vmixInputsByNumber]);
   
   // Combine inputs based on collapse states
   const filteredInputs = useMemo(() => {
@@ -704,15 +737,14 @@ const ShortcutGenerator = () => {
                 labelId="input-type-filter-label"
                 value={effectiveInputTypeFilter}
                 label={t('shortcut.filterInputType')}
-                onChange={(e) => setInputTypeFilter(e.target.value as string)}
+                onChange={(e) => {
+                  startTransition(() => setInputTypeFilter(e.target.value as string));
+                }}
                 size={spacing.iconSize}
               >
                 {availableInputTypes.map((type) => (
                   <MenuItem key={type} value={type}>
-                    {(type === 'All' ? t('common.all') : type)} {type === 'All' ? `(${regularInputs.length})` : `(${regularInputs.filter(input => {
-                      const vmixInput = vmixInputs.find(vi => vi.number === input.number);
-                      return vmixInput?.input_type === type;
-                    }).length})`}
+                    {(type === 'All' ? t('common.all') : type)} {type === 'All' ? `(${regularInputs.length})` : `(${inputTypeCounts.get(type) ?? 0})`}
                   </MenuItem>
                 ))}
               </Select>
@@ -752,7 +784,9 @@ const ShortcutGenerator = () => {
               </Typography>
               <IconButton
                 size={spacing.iconSize}
-                onClick={() => setFunctionConfigExpanded(!functionConfigExpanded)}
+                onClick={() => {
+                  startTransition(() => setFunctionConfigExpanded(prev => !prev));
+                }}
               >
                 {functionConfigExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
               </IconButton>
@@ -770,11 +804,11 @@ const ShortcutGenerator = () => {
                 }}
                 inputValue={sharedFunctionName}
                 onInputChange={(_event, newInputValue) => {
-                  setSharedFunctionName(newInputValue);
+                  startTransition(() => setSharedFunctionName(newInputValue));
                 }}
                 onChange={(_event, newValue) => {
                   if (newValue && typeof newValue !== 'string') {
-                    setSharedFunctionName(newValue.Name);
+                    startTransition(() => setSharedFunctionName(newValue.Name));
                   }
                 }}
                 renderInput={(params) => (
@@ -834,7 +868,9 @@ const ShortcutGenerator = () => {
                     key={funcName}
                     label={funcName}
                     size="small"
-                    onClick={() => setSharedFunctionName(funcName)}
+                    onClick={() => {
+                      startTransition(() => setSharedFunctionName(funcName));
+                    }}
                     color={sharedFunctionName === funcName ? 'primary' : 'default'}
                     variant={sharedFunctionName === funcName ? 'filled' : 'outlined'}
                     sx={{ flexShrink: 0 }}
@@ -1161,7 +1197,9 @@ const ShortcutGenerator = () => {
                 </Typography>
                 <IconButton
                   size={spacing.iconSize}
-                  onClick={() => setSpecialInputsExpanded(!specialInputsExpanded)}
+                  onClick={() => {
+                    startTransition(() => setSpecialInputsExpanded(prev => !prev));
+                  }}
                 >
                   {specialInputsExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
                 </IconButton>
@@ -1173,10 +1211,10 @@ const ShortcutGenerator = () => {
                 width={"100%"}
                 height={listHeight}
                 itemCount={filteredInputs.length}
-                itemSize={spacing.itemHeight + 46}
+                itemSize={spacing.itemHeight + 8}
                 itemData={useMemo(() => ({
                   filteredInputs,
-                  vmixInputs,
+                  vmixInputsByNumber,
                   selectedConnection,
                   showToast,
                   onTryCommand: tryCommand,
@@ -1184,7 +1222,7 @@ const ShortcutGenerator = () => {
                   onInputClick: handleInputClick,
                   spacing,
                   t,
-                }), [filteredInputs, vmixInputs, selectedConnection, showToast, tryCommand, lastClickedInputId, handleInputClick, spacing, t])}
+                }), [filteredInputs, vmixInputsByNumber, selectedConnection, showToast, tryCommand, lastClickedInputId, handleInputClick, spacing, t])}
               >
                 {VirtualizedInputItem}
               </VirtualizedInputList>
@@ -1193,21 +1231,7 @@ const ShortcutGenerator = () => {
         </>
       )}
 
-      {/* Toast Notification */}
-      <Snackbar 
-        open={toast.open} 
-        autoHideDuration={3000} 
-        onClose={handleCloseToast}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-      >
-        <Alert 
-          severity={toast.severity} 
-          sx={{ width: '100%' }}
-          variant="filled"
-        >
-          {toast.message}
-        </Alert>
-      </Snackbar>
+      <ToastSnackbar toast={toast} onClose={hideToast} />
     </Box>
   );
 };


### PR DESCRIPTION
## Summary
- Add custom Windows WiX (MSI) and NSIS installer templates, and build both bundles in CI/release workflows
- Improve navigation UX by keeping visited pages mounted with lazy preload on hover/focus
- Centralize toast notifications via `useToast` hook and add background-aware timeout handling for connection notifications
- Fix loading states in InputManager/ListManager, connection selection sync, and vMix status event listener stability

## Test plan
- [ ] Build Windows installer locally with `bun run tauri build -- --target x86_64-pc-windows-msvc --bundles msi,nsis`
- [ ] Verify MSI and NSIS installers install and launch the app correctly
- [ ] Navigate between pages and confirm visited pages retain state without full remount
- [ ] Test toast notifications on Blank Generator, Settings, Input Manager, and Shortcut Generator
- [ ] Connect/disconnect vMix and verify connection selector and notification behavior
- [ ] Confirm Input Manager and List Manager loading skeletons appear only during active fetches
