### PR TITLE
chore: set installer publisher and path to MikanseiLaboratory

### DIFF
--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 name = "app"
 version = "2.2.6"
 description = "app"
-authors = ["未完成成果物研究所"]
+authors = ["MikanseiLaboratory"]
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -31,6 +31,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "publisher": "MikanseiLaboratory",
     "createUpdaterArtifacts": true,
     "windows": {
       "wix": {

--- a/app/src-tauri/windows/installer.nsi
+++ b/app/src-tauri/windows/installer.nsi
@@ -77,8 +77,8 @@ OutFile "${OUTFILE}"
 ; We don't actually use this value as default install path,
 ; it's just for nsis to append the product name folder in the directory selector
 ; https://nsis.sourceforge.io/Reference/InstallDir
-!define INSTALL_PARENT_DIR "MikanseiLaboratory"
-!define INSTALL_RELATIVE_PATH "${INSTALL_PARENT_DIR}\${PRODUCTNAME}"
+; Default: C:\Program Files\${MANUFACTURER}\${PRODUCTNAME}
+!define INSTALL_RELATIVE_PATH "${MANUFACTURER}\${PRODUCTNAME}"
 !define PLACEHOLDER_INSTALL_DIR "placeholder\${INSTALL_RELATIVE_PATH}"
 InstallDir "${PLACEHOLDER_INSTALL_DIR}"
 

--- a/app/src-tauri/windows/main.wxs
+++ b/app/src-tauri/windows/main.wxs
@@ -119,7 +119,7 @@
                 </Component>
             </Directory>
             <Directory Id="$(var.PlatformProgramFilesFolder)" Name="PFiles">
-                <Directory Id="MikanseiLaboratoryDir" Name="MikanseiLaboratory">
+                <Directory Id="PublisherDir" Name="{{manufacturer}}">
                     <Directory Id="INSTALLDIR" Name="{{product_name}}"/>
                 </Directory>
             </Directory>


### PR DESCRIPTION
## Summary
- Set the installer publisher to `MikanseiLaboratory` for Windows (NSIS/MSI Manufacturer) and Linux (Debian Maintainer).
- Install under `C:\Program Files\MikanseiLaboratory\vmix-utility` by deriving the parent folder from the publisher. macOS/Linux keep their standard paths (`/Applications` and `/usr`).

## Test plan
- [ ] Confirm Windows NSIS/MSI Publisher is `MikanseiLaboratory` in Apps & Features.
- [ ] Confirm the default install path is `C:\Program Files\MikanseiLaboratory\vmix-utility`.
- [ ] Confirm Linux `.deb` Maintainer is `MikanseiLaboratory`.

Closes #282